### PR TITLE
fix: extract AM/PM from when-wrapper fallback in extractCheckInOutAmPm

### DIFF
--- a/src/__tests__/scraper/extraction.test.js
+++ b/src/__tests__/scraper/extraction.test.js
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseAppointmentPage, extractPricing } from '../../lib/scraper/extraction.js';
+import { parseAppointmentPage, extractPricing, extractCheckInOutAmPm } from '../../lib/scraper/extraction.js';
 import {
   mockAppointmentPage,
   mockAppointmentPageMinimal,
@@ -475,5 +475,29 @@ describe('REQ-200: extractPricing()', () => {
       const data = parseAppointmentPage(mockAppointmentPage);
       expect(data.all_pet_names[0]).toBe(data.pet_name);
     });
+  });
+});
+
+describe('extractCheckInOutAmPm()', () => {
+  it('extracts AM/PM from event-time-scheduled block', () => {
+    const html = `<div class="event-time-scheduled">
+      <span class="time the start"><span class="time-label" title="">AM</span>, </span>
+      <span class="time the"><span class="time-label" title="">PM</span>, </span>
+    </div>`;
+    expect(extractCheckInOutAmPm(html)).toEqual({ checkInAmPm: 'AM', checkOutAmPm: 'PM' });
+  });
+
+  it('extracts AM/PM from when-wrapper block (fallback)', () => {
+    const html = `<div class="dt-row" id="when-wrapper" data-start_scheduled="1772791200" data-end_scheduled="1773072900">
+      <div class="field-value"><span class="time the start"><span class="time-label" title="">AM</span>, </span>
+      <span class="time time-date">Friday, March 6, 2026</span><br>
+      <span class="time the"><span class="time-label" title="">PM</span>, </span>
+      <span class="time time-date">Monday, March 9, 2026</span></div>
+    </div>`;
+    expect(extractCheckInOutAmPm(html)).toEqual({ checkInAmPm: 'AM', checkOutAmPm: 'PM' });
+  });
+
+  it('returns nulls when neither block is present', () => {
+    expect(extractCheckInOutAmPm('<div>no time info</div>')).toEqual({ checkInAmPm: null, checkOutAmPm: null });
   });
 });

--- a/src/lib/scraper/extraction.js
+++ b/src/lib/scraper/extraction.js
@@ -195,8 +195,10 @@ function extractPageTitle(html) {
  * Returns { checkInAmPm: 'AM'|'PM'|null, checkOutAmPm: 'AM'|'PM'|null }.
  */
 export function extractCheckInOutAmPm(html) {
-  // Grab ~600 chars starting from the event-time-scheduled marker
-  const blockIdx = html.indexOf('event-time-scheduled');
+  // Grab ~600 chars starting from the event-time-scheduled marker.
+  // Some detail pages use class="event-time-scheduled"; others use id="when-wrapper".
+  let blockIdx = html.indexOf('event-time-scheduled');
+  if (blockIdx === -1) blockIdx = html.indexOf('when-wrapper');
   if (blockIdx === -1) return { checkInAmPm: null, checkOutAmPm: null };
   const block = html.slice(blockIdx, blockIdx + 600);
 


### PR DESCRIPTION
## Summary
- extractCheckInOutAmPm was only searching for class='event-time-scheduled' as the anchor block
- Some appointment detail pages use id='when-wrapper' instead (e.g. C63QgUt9, C63QgNHs, C63QfLnk)
- Added when-wrapper as fallback so AM/PM is captured for all appointment types
- Added 3 tests covering both anchor variants and the no-match case

## Root cause
The external site HTML uses two different structures depending on appointment type:
- class='event-time-scheduled' (some appointments)
- id='when-wrapper' (others — confirmed from live HTML of C63QgUt9)

Both contain the same time-label spans with AM/PM.

## Test plan
- [ ] CI passes
- [ ] After merge + deploy, re-sync affected boardings (Oscar/C63QgUt9, Millie McSpadden/C63QgNHs, Mochi Hill/C63QfLnk) and confirm arrival_ampm populated