### PR TITLE
feat: v4.0 daytime schedule ingestion

### DIFF
--- a/api/cron-schedule.js
+++ b/api/cron-schedule.js
@@ -24,6 +24,7 @@ import { setSession } from '../src/lib/scraper/auth.js';
 import { authenticatedFetch } from '../src/lib/scraper/auth.js';
 import { getSession, clearSession } from '../src/lib/scraper/sessionCache.js';
 import { enqueue, getQueueDepth } from '../src/lib/scraper/syncQueue.js';
+import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from '../src/lib/scraper/daytimeSchedule.js';
 import { writeCronHealth } from './_cronHealth.js';
 
 export const config = { runtime: 'nodejs' };
@@ -228,7 +229,7 @@ export default async function handler(req, res) {
     console.log(`[CronSchedule] 📅 Starting scan — cursor: ${cursorDate.toDateString()}, mode: micro`);
     console.log(`[CronSchedule] 🔑 Session: cached`);
 
-    const stats = { pagesScanned: 0, found: 0, skipped: 0, queued: 0 };
+    const stats = { pagesScanned: 0, found: 0, skipped: 0, queued: 0, daytimeUpserted: 0, daytimeErrors: 0 };
 
     // Fetch current week + cursor week (deduplicated)
     const datesToFetch = [today];
@@ -238,6 +239,9 @@ export default async function handler(req, res) {
 
     const seenIds = new Set();
     const appointments = [];
+    // Accumulates all daytime/boarding events across both fetched pages.
+    // upsertDaytimeAppointments deduplicates before the DB write.
+    const allDaytimeAppts = [];
 
     for (const date of datesToFetch) {
       let html;
@@ -262,6 +266,12 @@ export default async function handler(req, res) {
         seenIds.add(appt.id);
         appointments.push(appt);
       }
+
+      // Parse ALL events (DC, PG, Boarding) for daytime activity ingestion.
+      // Runs against the same HTML — no extra fetches.
+      const daytimeAppts = parseDaytimeSchedulePage(html);
+      console.log(`[CronSchedule] 🏃 Parsed ${daytimeAppts.length} daytime events on ${date.toDateString()} page`);
+      allDaytimeAppts.push(...daytimeAppts);
     }
 
     stats.found = appointments.length;
@@ -291,6 +301,13 @@ export default async function handler(req, res) {
     }
 
     console.log(`[CronSchedule] 🐕 ${stats.found} found, ${stats.skipped} skipped (non-boarding), ${stats.queued} queued`);
+
+    // Upsert all daytime appointments collected from every fetched page.
+    // This runs after the boarding queue loop so queue errors don't block it.
+    const daytimeResult = await upsertDaytimeAppointments(supabase, allDaytimeAppts);
+    stats.daytimeUpserted = daytimeResult.upserted;
+    stats.daytimeErrors = daytimeResult.errors;
+    console.log(`[CronSchedule] 📊 Daytime upserted: ${daytimeResult.upserted}, errors: ${daytimeResult.errors}`);
 
     // Advance cursor
     const nextCursor = advanceCursor(cursorDate);

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,29 +1,243 @@
-# Dog Boarding App — Session Handoff (v3.2)
-**Last updated:** March 5, 2026 (v3.2 — stale title bug fix)
-**Status:** v3.2 committed at `4bfc212`. **One manual step required before deploying — see below.**
+# Dog Boarding App — Session Handoff (v3.2 deployed + v4 planning)
+**Last updated:** March 5, 2026 (v3.2 deployed, v4 planning started)
 
 ---
 
 ## Current State
 
-- **692 tests pass** (all 692 — 4 additional tests added this session).
-- **`main`** local is at `4bfc212`, ahead of `origin/main` (`a8abb6e`). Not yet pushed.
-- **Live URL:** [qboarding.vercel.app](https://qboarding.vercel.app) (still running v3.1)
+- **v3.2 is LIVE** at [qboarding.vercel.app](https://qboarding.vercel.app)
+- PR #37 merged, deployed, tested — stale title month fix working correctly
+- Migration 017 applied in Supabase (`arrival_ampm`, `departure_ampm` columns exist)
+- RLS enabled on `sync_queue` table in Supabase
+- v3.3 Payroll Report deferred to a future version (not v3.3 — pick a new version number TBD)
+- **No uncommitted code.** Clean working tree.
 
-## IMMEDIATE NEXT ACTIONS (do these first)
+---
 
-1. **Apply migration 017 in Supabase SQL editor** (before pushing — sync will fail silently if columns don't exist):
-   ```sql
-   ALTER TABLE boardings
-     ADD COLUMN IF NOT EXISTS arrival_ampm TEXT,
-     ADD COLUMN IF NOT EXISTS departure_ampm TEXT;
-   ```
-2. **Push to deploy:** `git push origin main`
-3. **Verify deployment:** trigger a Sync Now for a boarding with a known check-in (e.g., C63QgUhM). Confirm `boardings` table has `arrival_ampm='AM'`, `departure_ampm='PM'`. DogsPage should show `Mar 4, 2026 AM` instead of `Mar 4, 2026 12:00 AM`.
+## IMMEDIATE NEXT ACTIONS
+
+None. v3.2 is done. Next work is v4 planning and implementation.
+
+---
+
+## v4 — Daytime Activity Intelligence
+
+### Goal
+Ingest ALL daytime dog activities (Daycare + Playgroup) from the schedule page, not just boardings. First deliverable: a "picture of the day" message per worker showing who's in their group, who was added vs. yesterday, who was removed.
+
+### Delivery phases
+1. **v4.0** — Data ingestion: parse full schedule page, store all daytime appointments
+2. **v4.1** — "Picture of the day" API: per-worker summary with day-over-day diff
+3. **v4.2** — WhatsApp notifications: 4am PST daily, re-check 7am + 8:30am PST
+
+---
+
+### What the schedule page gives us (no detail fetches needed)
+
+Each `.day-event <a>` element on the weekly grid (`/schedule/days-7/YYYY/M/D`) exposes:
+
+| Data | Source |
+|---|---|
+| Appointment external ID | `data-id` |
+| Day-column date | `data-ts` (Unix ts, midnight of that day) |
+| Actual check-in time | `data-start` (Unix ts) |
+| Status | `data-status` (1=upcoming, 5=in-progress, 6=completed) |
+| Recurring series ID | `data-series` (stable across same dog's recurring appts) |
+| Worker ID | class `ew-{uid}` (0 = no worker = boardings) |
+| Service category + type | classes `cat-{id}` `ser-{id}` |
+| Title (free-form) | `.day-event-title` inner text |
+| Display time | `.day-event-time` inner text |
+| Client UID | `data-uid` on `.event-clients-pets` |
+| Client name | `.event-client` inner text |
+| Pet external IDs | `data-pet` on each `.event-pet-wrapper` |
+| Pet names | `.event-pet` inner text |
+| Multi-day span | classes `appt-before`, `appt-after`, `appt-all-day` |
+
+### Workers (confirmed from HTML)
+| Name | External UID |
+|---|---|
+| Charlie | 61023 |
+| Kathalyn Dominguez | 208669 |
+| Kentaro Cavey | 141407 |
+| Max Posse | 174385 |
+| Sierra Tagle | 189436 |
+| Stephen Muro | 164375 |
+| No worker set (boardings) | 0 |
+
+### Service categories (confirmed)
+| Category | cat-ID | service | ser-ID |
+|---|---|---|---|
+| Daycare | 5634 | Daycare Monthly | 10692 |
+| Playgroup | 7431 | Playgroup Monthly | 15824 |
+| Boarding | 5635 | Boarding (Nights) | 17357 |
+| Boarding | 5635 | Boarding (Days) | 11778 |
+| Boarding | 5635 | Boarding discounted (DC FT) | 22215 |
+| Boarding | 5635 | Staff Boarding (nights) | 22387 |
+
+### Title patterns observed
+- `DC:FT` = Daycare full-time (every day)
+- `DC M/T/W/TH` = Daycare specific days
+- `PG FT` = Playgroup full-time
+- `PG M/W/TH` = Playgroup specific days
+- `ADD Leo T/TH` = Adding extra dog on Tue/Thu (title names the dog)
+- `D/C FT OFF OFF` = Daycare FT with days off
+- `Pick-Up 9AM-10AM` / `Pick-Up ( 9 am - 10 am )` = morning pickup slot (status=1, not yet checked in)
+
+### Day-over-day diff logic (how to compute adds/removes)
+`data-series` is stable for recurring appointments of the same dog with the same worker.
+- For each worker: collect `Set<series_id>` for day N and day N-1
+- Added = in N but not N-1
+- Removed = in N-1 but not N
+- No heuristics needed — this is exact.
+
+---
+
+### New DB tables needed
+
+**`workers`**
+```sql
+CREATE TABLE workers (
+  id SERIAL PRIMARY KEY,
+  external_id INTEGER UNIQUE NOT NULL,  -- e.g. 61023
+  name TEXT NOT NULL,
+  active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+**`daytime_appointments`**
+```sql
+CREATE TABLE daytime_appointments (
+  id SERIAL PRIMARY KEY,
+  external_id TEXT NOT NULL,            -- data-id, e.g. "C63QgUnJ"
+  series_id TEXT,                       -- data-series, e.g. "C63QgUl0"
+  appointment_date DATE NOT NULL,       -- derived from data-ts
+  worker_external_id INTEGER,           -- ew-{uid}; 0 = no worker
+  service_category TEXT,               -- "DC", "PG", "Boarding"
+  service_cat_id INTEGER,              -- e.g. 5634
+  service_id INTEGER,                  -- e.g. 10692
+  title TEXT,
+  status INTEGER,                       -- 1, 5, 6
+  start_ts BIGINT,                      -- data-start (Unix ts)
+  day_ts BIGINT,                        -- data-ts (Unix ts)
+  display_time TEXT,                   -- ".day-event-time" text
+  client_uid INTEGER,
+  client_name TEXT,
+  pet_ids INTEGER[],                    -- array of data-pet values
+  pet_names TEXT[],
+  is_pickup BOOLEAN DEFAULT FALSE,      -- display_time contains "Pick-Up"
+  is_multiday_start BOOLEAN DEFAULT FALSE,  -- has class appt-after
+  is_multiday_end BOOLEAN DEFAULT FALSE,    -- has class appt-before
+  synced_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(external_id, appointment_date) -- same appt can appear on multiple days
+);
+CREATE INDEX ON daytime_appointments(appointment_date, worker_external_id);
+CREATE INDEX ON daytime_appointments(series_id);
+```
+
+---
+
+### v4.0 Pre-Implementation Review (Staff Engineer sign-off)
+
+**Decision Log — critical branching points and what to log at each:**
+
+| Branching Point | Decision Data Logged |
+|---|---|
+| Week parse begins | Total `<a data-id>` blocks found in HTML |
+| Per-event: date resolution | `external_id`, raw `data-ts`, resolved `appointment_date`; skip + warn if unparseable |
+| Per-event: worker extraction | `external_id`, matched `ew-{uid}`; warn if uid not in `KNOWN_WORKERS` |
+| Per-event: service classification | `external_id`, matched `cat-{id}`/`ser-{id}`, resolved `service_category`; warn if unknown cat |
+| Per-event: pet extraction | Warn if zero pet IDs found on a non-boarding event |
+| Upsert batch | Count in, count deduped, errors from Supabase |
+
+**Pattern alignment:**
+- Pure parse + separate persistence (same split as `forms.js`) — `parseDaytimeSchedulePage` is side-effect-free
+- Flat output array per event; no nested structures
+- Regex-only (no DOMParser) — Node.js cron safe; same rule as `forms.js`
+- Named constants (`SERVICE_CATS`, `KNOWN_WORKERS`) at top of file — unknown IDs warn but never silently misclassify
+- No deduplication inside the parser — `UNIQUE(external_id, appointment_date)` is the source of truth; deduplicate only in upsert helper before sending batch
+
+**Anti-patterns explicitly avoided:**
+- No DOMParser (this is cron-first, unlike `schedule.js`)
+- No stateful class — module with exported functions
+- No inline Supabase client construction
+- No cross-page deduplication inside the parser (multi-day spans are intentionally one row per day)
+
+**Implementation strategy:**
+1. Define `SERVICE_CATS`, `KNOWN_WORKERS`, `PICKUP_RE` constants at top — drives classification + warning system
+2. Three small private helpers: `attr(attrStr, name)`, `innerText(html, cls)`, `tsToDate(unixSeconds)`
+3. `parseDaytimeSchedulePage(html)` — pure; outer loop matches all `<a data-id="...">` blocks, inner extraction per event
+4. `upsertDaytimeAppointments(supabase, appointments)` — deduplicates batch by `(external_id, appointment_date)`, single bulk upsert
+5. Wire into `cron-schedule.js` — same HTML already in hand, no new fetches; accumulate across pages, upsert after loop
+
+**Implementation guidelines (Go signal):**
+- Chain-of-thought comments on every function: intended behavior + error-handling strategy
+- Structured logging: log input params at function entry; log "Decision Data" at every major gate (`data-ts missing → skip`, `unknown cat-id → warn but continue`)
+- DRY: shared `attr()` and `innerText()` helpers used everywhere; no repeated attribute-extraction inline
+- Testable: pure parse function can be unit-tested with a fixture HTML string, no mocking needed
+
+---
+
+### New scraper code needed
+
+**`src/lib/scraper/daytimeSchedule.js`** (new file)
+- `parseDaytimeSchedulePage(html, weekStartDate)` → array of appointment objects
+  - Parse each `.cal-day` cell by `data-year/month/day`
+  - Within each cell, parse each `.day-event` `<a>`
+  - Extract all fields from the table above
+  - Return flat array: `[{ external_id, series_id, appointment_date, worker_external_id, ... }]`
+- `upsertDaytimeAppointments(appointments)` → upsert to Supabase `daytime_appointments`
+- This runs from Node.js (cron) so must use regex, not DOMParser
+
+**Update `api/cron-schedule.js`**
+- After fetching each schedule page, also call `parseDaytimeSchedulePage`
+- Upsert daytime appointments alongside boarding queue logic
+
+---
+
+### WhatsApp integration options
+- **Twilio** (simplest, has Node SDK, free trial) — recommended starting point
+- **Meta Cloud API** (official, free up to 1000 conversations/month)
+- **Baileys** (unofficial, no account needed, but risky ToS)
+
+Cron schedule for notifications (Vercel Hobby allows multiple crons):
+- 4am PST = 12:00 UTC (or 11:00 UTC after DST change March 8)
+- 7am PST = 15:00 UTC
+- 8:30am PST = 16:30 UTC
+
+Logic per notification:
+1. Fetch today's daytime_appointments (grouped by worker)
+2. Fetch yesterday's daytime_appointments (grouped by worker)
+3. Compute diff
+4. If 4am: always send
+5. If 7am or 8:30am: only send if diff vs. last-sent snapshot is non-empty
+
+---
+
+### "Picture of the day" message format (per worker)
+```
+Thursday Mar 5 - UPDATED!
+
+Charlie (1 dog)
+  Bronwyn Cottrell
+
+Kathalyn Dominguez (5 dogs)
+  John McClane (Stevenson) + Chester (Petry) + Billy (Cirelli) + Buddy Peters (Doan) + "Waldo" (McComb)
+
+[etc per worker...]
+
+Boarders today: Benny, Millie, Bowie, Peanut, Annie, Tracy
+```
+
+Added/removed lines:
+```
+  + Frances Wiebe [NEW from yesterday]
+  - Tasha See [NOT TODAY]
+```
+
+---
 
 ## Cron health (as of March 4, 2026)
-
-Crons ran overnight at their scheduled UTC times (UTC midnight = 4pm PST day prior):
 - `schedule` — 00:18 UTC → queued 14, skipped 124, 1 page scanned, cursor to 2026-03-10
 - `detail` — 00:27 UTC → idle (queue already empty)
 - `auth` — 00:54 UTC → skipped (session still valid)
@@ -36,141 +250,25 @@ SELECT status, type, COUNT(*) FROM sync_queue GROUP BY status, type ORDER BY typ
 
 ---
 
-## v3.1 What Was Done (March 4, 2026 — sessions 1–3)
+## v3.2 What Was Done
 
-### Housekeeping (session 3) ✅
-- PR #34 confirmed merged (CI fully green)
-- Local `main` fast-forwarded to match `origin/main`
-- "Restrict force pushes" re-enabled in GitHub Rulesets
-- RLS enabled on `sync_queue` in Supabase
-- `Co-Authored-By: Claude` stripped from all commit messages (all branches + tags) via `git filter-branch --tag-name-filter cat` + force-push
+### Deployed and working
+- AM/PM capture from external site's `.event-time-scheduled` block
+- `arrival_ampm` / `departure_ampm` columns on `boardings` (migration 017 applied)
+- DogsPage shows "Mar 4, 2026 AM" when ampm present
+- CalendarPage detail panel + print section show AM/PM
+- SyncSettings dead UI removed (auto-sync toggle, interval, setup mode)
+- PR #37 stale title month fix deployed and confirmed working
 
-### Git history rewrite (session 1) ✅
-All 218 commits rewritten to use `kcoffie@gmail.com` (was `kcoffie@directcommerce.com`, no longer valid). Force-pushed to all branches (main, fix/v3.1-code-hardening, uat, develop) and tags. Local git config updated: `git config user.email "kcoffie@gmail.com"`.
-
-### Tests: 697/697 passing ✅
-Fixed 9 pre-existing test failures + 2 CI-only failures:
-
-1. **BoardingMatrix sorting tests** (`src/components/BoardingMatrix.test.jsx`): Added mocks for `useBoardingForms`, `EmployeeDropdown`, `BoardingFormModal`. Fixed `getDogNamesInOrder` helper: dog name is in `<button>`, not `spans[1]`.
-2. **DateNavigator DST test**: `Math.floor` → `Math.round` (fixes flakiness near DST boundary).
-3. **CsvImport.test.jsx** (CI-only fail): Replaced stale `useLocalStorage` mock with `DataContext` mock — test was written before Supabase migration and still used localStorage mock; `DataProvider` imported supabase at module load time without env vars.
-4. **DogsPage.pastBoardings.test.jsx** (CI-only fail): Added `vi.mock('../../hooks/useBoardingForms', ...)` — DataContext was mocked but `DogsPage` also imports `useBoardingForms` directly → supabase import chain.
-
-### Code fixes in PR `fix/v3.1-code-hardening` ✅
-- **sync.js**: drain loop cap (`MAX_DRAIN = 20`) — prevents runaway drain in browser sync
-- **forms.js**: date validation in `parseMMDDYYYYtoISO` — reject month > 12 or day > 31
-- **BoardingFormModal.jsx**: popup blocker alert — was silently failing; now `alert()`s if `window.open()` returns null
-
-### Lint: all 21 errors/warnings fixed ✅
-Fixed across 16 files (unused imports, unused vars, eslint-disable comments for known-acceptable patterns).
-
-### README updated ✅
-Added live URL, boarding forms feature description, updated project structure, removed version references.
-
-### Supabase: enable RLS on sync_queue ⚠️ PENDING
-```sql
-ALTER TABLE public.sync_queue ENABLE ROW LEVEL SECURITY;
-```
-Safe — table only accessed by service role (crons + sync proxy), which bypasses RLS. No policies needed.
-
----
-
-## Bug Fix (March 5, 2026) — Stale title month causes wrong-month date parsing
-
-**Symptom:** Appointment `C63QgT8L` (Annie & Tracy, Michael Tam, March 5–7) was skipped as "out-of-range" during a March sync. Client had entered title `"2/5-7"` (originally a Feb booking, or a typo), which `parseServiceTypeDates` parsed as Feb 5–7. System timestamps correctly said March 5–7 but were only used as a fallback when the title had *no* parseable dates at all.
-
-**Fix in `extraction.js` (`parseAppointmentPage`):** After parsing title dates, cross-validate against the `data-start_scheduled` system timestamp. If a reasonable timestamp (within ±2 years of now) differs from the title date by >20 days, the title month is stale/wrong → use the system timestamps instead. Far-future/bogus timestamps (e.g. `9999999999`) are ignored.
-
-**Test added:** `falls back to system timestamps when title month is stale/wrong (>20 day gap)` in `extraction.test.js`.
-
----
-
-## v3.2 What Was Done (March 4, 2026)
-
-### AM/PM capture & display ✅
-- `extraction.js`: added `extractCheckInOutAmPm(html)` — grabs `event-time-scheduled` block, collects `.time-label` spans → `{ checkInAmPm, checkOutAmPm }`. Added `check_in_ampm` / `check_out_ampm` to `parseAppointmentPage` return.
-- `supabase/migrations/017_add_ampm_columns.sql`: adds `arrival_ampm TEXT`, `departure_ampm TEXT` to `boardings` table. **Apply manually in Supabase SQL editor before syncing.**
-- `mapping.js`: `mapToBoarding` includes `arrival_ampm`/`departure_ampm`. `upsertBoarding` writes them on update.
-- `useBoardings.js`: transform includes `arrivalAmPm`/`departureAmPm`.
-- `DogsPage.jsx`: `formatDateWithAmPm(dt, ampm)` helper — shows `Mar 4, 2026 AM` when ampm present, falls back to `formatDateTime`. Applied to desktop table + mobile cards.
-- `CalendarPage.jsx`: `calendarBookings` useMemo includes `arrival_ampm`/`departure_ampm`. Detail panel: arriving shows `AM →`, departing shows `→ PM`. PrintSection shows ampm in arriving/departing/staying rows.
-
-### SyncSettings cleanup ✅
-- Removed dead UI: "Automatic Sync" toggle, "Sync Interval" select, "Setup Mode" toggle + info banner + confirmation dialog.
-- `useSyncSettings.js`: removed `toggleEnabled`, `setInterval`, `toggleSetupMode` functions and `updateSyncSettings` import.
-- `SyncSettings.test.jsx` + `useSyncSettings.test.js`: updated to not reference removed functions.
-
----
-
-## v3.2 Next Steps / Backlog
-
-### v3.3 Payroll Report (planned design — ready to implement)
-New section at bottom of `PayrollPage.jsx`. New component `src/components/PayrollReport.jsx`.
-
-Layout:
-```
-Payroll Report: Mar 4 – Apr 3, 2026                    [Print]
-
-Employee       | Mar 4 | Mar 5 | ... | Apr 3 | Total
----------------|-------|-------|-----|-------|-------
-Alex           |  2/$80|  3/$120| ...| 1/$40 | $840
-Jordan         |   —   |  1/$40 | ...| 2/$80 | $520
-```
-- Each cell: `{numDogs} dog(s) / ${net_amount}` (employee's take, not gross)
-- Cell bg: light green if date is in `getPaidDatesForEmployee()`
-- Total column: sum of all net amounts for that employee
-- Print: `window.print()` + `@media print` CSS
-
-Data per cell:
-- `getNightAssignment(dateStr)` → which employee worked that night
-- Dogs overnight that night: `boardings.filter(b => isOvernight(b, dateStr))`
-- Net per dog: `dog.nightRate * getNetPercentageForDate(dateStr) / 100`
-- Paid check: `getPaidDatesForEmployee(employeeId).has(dateStr)`
-
-### Longer-term
-- Fix status field extraction (always null — `.appt-change-status` needs `textContent` on `<a><i>`)
-- **Low priority:** Store datetimes in PST (America/Los_Angeles) instead of UTC
-
----
-
-## v3.0 Summary (what was built)
-
-- **REQ-500:** Pet ID extraction → `external_pet_id` on dogs table
-- **REQ-501:** Forms scraping pipeline (`forms.js`) — fetch, parse, match, store boarding intake forms
-- **REQ-502:** Date discrepancy detection (`date_mismatch` flag on `boarding_forms`)
-- **REQ-503:** Boarding Form Modal — priority fields, date mismatch alert, print, source URL link
-- **REQ-504:** Missing form indicator — red/amber/indigo/slate dog name links in matrix
-- **REQ-505:** Forms scraper logging
-- **REQ-506:** Modal centering fix via React portal
-- **REQ-507:** Dog link three-state color coding
-- **REQ-508:** Source URL link + conditional Print button
-
-Key fixes in v3.0:
-- `.single()` → `.maybeSingle()` everywhere (killed 406 console errors)
-- Sync Now drains all pending form queue items (not just appointments)
-- Form field regex: `id="(field_\d+)-wrapper"` (not bare field ID)
-- Form matching: strict 7-day submission window, no fallback to stale forms
-- Print: isolated `_blank` window (avoids blank output from full-page print)
-- Re-enqueue: `boarding_forms` is source of truth; reset done→pending when form not yet stored
-
-See full session log: `docs/archive/SESSION_HANDOFF_v3.0_final.md`
-
----
-
-## Decisions Locked In
-
-- **Rate fallback:** `boarding.night_rate ?? dog.night_rate ?? 0`
-- **HASH_FIELDS:** identity/structure only — pricing fields intentionally excluded
-- **Unchanged path:** explicitly writes `appointment_total` + `pricing_line_items` when present
-- **Multi-pet:** secondary external_id = `{appt_id}_p{index}`
-- **sync_status column:** `sync_status = 'archived'` — `is_archived` does not exist
-- **`.maybeSingle()` vs `.single()`:** All existence-check find* queries use `.maybeSingle()`. Never `.single()` for existence checks.
-- **Form matching:** 7-day window `(arrival − 7 days)` to `(arrival day)` inclusive. No fallback.
-- **Form re-enqueue:** `boarding_forms` is source of truth. `resetIfDone: true` allows re-processing previously-done queue items when form not yet stored.
-- **VITE_SYNC_PROXY_TOKEN:** intentionally VITE_-prefixed (browser readable); different from `CRON_SECRET`
-- **cron-detail:** 1 queue item per invocation (Hobby plan). "Sync Now" drains all pending form items.
-- **Form field regex:** `id="(field_\d+)-wrapper"` — external site uses `-wrapper` suffix
-- **historicalSync.js:** kept — useful for full data rebuild, not dead code
+### Decisions locked in
+- Rate fallback: `boarding.night_rate ?? dog.night_rate ?? 0`
+- HASH_FIELDS: identity/structure only — pricing fields intentionally excluded
+- Unchanged path: explicitly writes `appointment_total` + `pricing_line_items` when present
+- Multi-pet: secondary external_id = `{appt_id}_p{index}`
+- `sync_status = 'archived'` — `is_archived` does not exist
+- `.maybeSingle()` for all existence checks. Never `.single()` for 0-row-valid queries
+- Form matching: 7-day window `(arrival − 7 days)` to `(arrival day)` inclusive. No fallback.
+- Form field regex: `id="(field_\d+)-wrapper"` — external site uses `-wrapper` suffix
 
 ---
 
@@ -208,8 +306,11 @@ DELETE FROM boardings WHERE external_id = 'REPLACE_ME';
 
 ---
 
-## Archive
+## GitHub Releases
+- v1.0, v1.2.0, v2.0.0, v3.0.0, v3.1.0, v3.2.0 (Latest)
+- Next release after v4.0 merges: tag `v4.0.0`
 
+## Archive
 - v3.0 full session log: `docs/archive/SESSION_HANDOFF_v3.0_final.md`
 - v2.4 full session log: `docs/archive/SESSION_HANDOFF_v2.4_final.md`
 - Earlier versions: `docs/archive/SESSION_HANDOFF_v2.{0-3}_final.md`

--- a/src/__tests__/scraper/daytimeSchedule.test.js
+++ b/src/__tests__/scraper/daytimeSchedule.test.js
@@ -1,0 +1,296 @@
+/**
+ * Tests for the daytime schedule parser (v4.0 Activity Intelligence).
+ *
+ * parseDaytimeSchedulePage is a pure function — all tests use fixture HTML
+ * strings and require no mocking, no I/O, no Supabase client.
+ *
+ * @requirements REQ-v4.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseDaytimeSchedulePage } from '../../lib/scraper/daytimeSchedule.js';
+
+// ---------------------------------------------------------------------------
+// Timestamp constants
+// 1772668800 = 2026-03-05 00:00:00 UTC  (day column midnight)
+// 1772755200 = 2026-03-06 00:00:00 UTC  (day column midnight, next day)
+// 1772697600 = 2026-03-05 08:00:00 UTC  (actual 8am check-in)
+// ---------------------------------------------------------------------------
+const TS_MAR5 = 1772668800;
+const TS_MAR6 = 1772755200;
+const TS_8AM  = 1772697600;
+
+// ---------------------------------------------------------------------------
+// HTML builder helpers — construct minimal but realistic event <a> blocks
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a single day-event <a> block matching the external site's structure.
+ * All params are optional; sensible defaults are provided.
+ */
+function buildEvent({
+  id         = 'C63QgUnJ',
+  series     = 'C63QgUl0',
+  dayTs      = TS_MAR5,
+  startTs    = TS_8AM,
+  status     = 1,
+  classes    = 'day-event ew-61023 cat-5634 ser-10692',
+  title      = 'DC:FT',
+  time       = '8am - 6pm',
+  clientUid  = 12345,
+  clientName = 'Kate Coffie',
+  pets       = [{ id: 90043, name: 'Benny' }],
+} = {}) {
+  const petHtml = pets
+    .map(
+      p => `
+      <div class="event-pet-wrapper" data-pet="${p.id}">
+        <span class="event-pet">${p.name}</span>
+      </div>`
+    )
+    .join('');
+
+  return `
+<a href="/schedule/a/${id}/${dayTs}"
+   data-id="${id}"
+   data-series="${series}"
+   data-ts="${dayTs}"
+   data-start="${startTs}"
+   data-status="${status}"
+   class="${classes}">
+  <div class="day-event-title">${title}</div>
+  <div class="day-event-time">${time}</div>
+  <div class="event-clients-pets" data-uid="${clientUid}">
+    <span class="event-client">${clientName}</span>
+    ${petHtml}
+  </div>
+</a>`;
+}
+
+/** Wrap one or more event blocks in a minimal schedule page shell. */
+function buildPage(...events) {
+  return `<html><body><div class="schedule-grid">${events.join('\n')}</div></body></html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('parseDaytimeSchedulePage()', () => {
+  // --- Basic behaviour ---
+
+  it('returns an empty array for empty HTML', () => {
+    expect(parseDaytimeSchedulePage('')).toEqual([]);
+    expect(parseDaytimeSchedulePage('<html><body></body></html>')).toEqual([]);
+  });
+
+  it('returns an empty array when no day-event links are present', () => {
+    const html = '<html><body><a href="/schedule">Home</a></body></html>';
+    expect(parseDaytimeSchedulePage(html)).toEqual([]);
+  });
+
+  // --- Field extraction: DC event ---
+
+  it('parses all fields from a Daycare event', () => {
+    const html = buildPage(buildEvent());
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.external_id).toBe('C63QgUnJ');
+    expect(appt.series_id).toBe('C63QgUl0');
+    expect(appt.appointment_date).toBe('2026-03-05');
+    expect(appt.worker_external_id).toBe(61023);
+    expect(appt.service_category).toBe('DC');
+    expect(appt.service_cat_id).toBe(5634);
+    expect(appt.service_id).toBe(10692);
+    expect(appt.title).toBe('DC:FT');
+    expect(appt.status).toBe(1);
+    expect(appt.start_ts).toBe(TS_8AM);
+    expect(appt.day_ts).toBe(TS_MAR5);
+    expect(appt.display_time).toBe('8am - 6pm');
+    expect(appt.client_uid).toBe(12345);
+    expect(appt.client_name).toBe('Kate Coffie');
+    expect(appt.pet_ids).toEqual([90043]);
+    expect(appt.pet_names).toEqual(['Benny']);
+    expect(appt.is_pickup).toBe(false);
+    expect(appt.is_multiday_start).toBe(false);
+    expect(appt.is_multiday_end).toBe(false);
+  });
+
+  // --- Service category resolution ---
+
+  it('resolves service_category="PG" for cat-7431 / ser-15824', () => {
+    const html = buildPage(buildEvent({ classes: 'day-event ew-208669 cat-7431 ser-15824' }));
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.service_category).toBe('PG');
+    expect(appt.service_cat_id).toBe(7431);
+    expect(appt.service_id).toBe(15824);
+  });
+
+  it('resolves service_category="Boarding" for cat-5635 / ser-17357', () => {
+    const html = buildPage(
+      buildEvent({ classes: 'day-event ew-0 cat-5635 ser-17357', title: '3/3-3/7pm' })
+    );
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.service_category).toBe('Boarding');
+    expect(appt.worker_external_id).toBe(0);
+  });
+
+  it('sets service_category=null and still parses event for an unknown cat-id', () => {
+    // cat-9999 is not in SERVICE_CATS — parser should warn and continue
+    const html = buildPage(
+      buildEvent({ id: 'UNKNOWN1', classes: 'day-event ew-61023 cat-9999 ser-99999' }),
+      buildEvent({ id: 'KNOWN1' })  // should still be parsed
+    );
+    const results = parseDaytimeSchedulePage(html);
+
+    expect(results).toHaveLength(2);
+    const unknown = results.find(a => a.external_id === 'UNKNOWN1');
+    expect(unknown.service_category).toBeNull();
+    expect(unknown.service_cat_id).toBe(9999);
+  });
+
+  // --- Multi-event page ---
+
+  it('returns all events from a page with multiple events', () => {
+    const html = buildPage(
+      buildEvent({ id: 'AAA111', series: 'A1' }),
+      buildEvent({ id: 'BBB222', series: 'B2', classes: 'day-event ew-208669 cat-7431 ser-15824' }),
+      buildEvent({ id: 'CCC333', series: 'C3', classes: 'day-event ew-0 cat-5635 ser-17357' })
+    );
+    const results = parseDaytimeSchedulePage(html);
+
+    expect(results).toHaveLength(3);
+    expect(results.map(a => a.external_id)).toEqual(['AAA111', 'BBB222', 'CCC333']);
+  });
+
+  // --- Multi-day span ---
+
+  it('emits two rows when the same external_id appears in two day columns', () => {
+    // Boarding spans Mar 5 → Mar 6: same data-id, different data-ts
+    const html = buildPage(
+      buildEvent({ id: 'SPAN01', dayTs: TS_MAR5, classes: 'day-event ew-0 cat-5635 ser-17357 appt-after' }),
+      buildEvent({ id: 'SPAN01', dayTs: TS_MAR6, classes: 'day-event ew-0 cat-5635 ser-17357 appt-before' })
+    );
+    const results = parseDaytimeSchedulePage(html);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].appointment_date).toBe('2026-03-05');
+    expect(results[1].appointment_date).toBe('2026-03-06');
+    // Both rows share the same external_id
+    expect(results[0].external_id).toBe('SPAN01');
+    expect(results[1].external_id).toBe('SPAN01');
+  });
+
+  it('sets is_multiday_start=true for appt-after class', () => {
+    const html = buildPage(
+      buildEvent({ classes: 'day-event ew-0 cat-5635 ser-17357 appt-after' })
+    );
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.is_multiday_start).toBe(true);
+    expect(appt.is_multiday_end).toBe(false);
+  });
+
+  it('sets is_multiday_end=true for appt-before class', () => {
+    const html = buildPage(
+      buildEvent({ classes: 'day-event ew-0 cat-5635 ser-17357 appt-before' })
+    );
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.is_multiday_start).toBe(false);
+    expect(appt.is_multiday_end).toBe(true);
+  });
+
+  it('sets both multiday flags for a middle-day span (appt-before appt-after)', () => {
+    const html = buildPage(
+      buildEvent({ classes: 'day-event ew-0 cat-5635 ser-17357 appt-before appt-after' })
+    );
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.is_multiday_start).toBe(true);
+    expect(appt.is_multiday_end).toBe(true);
+  });
+
+  // --- Pick-up detection ---
+
+  it('sets is_pickup=true when title contains "Pick-Up"', () => {
+    const html = buildPage(buildEvent({ title: 'Pick-Up 9AM-10AM', time: '9am - 10am' }));
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.is_pickup).toBe(true);
+  });
+
+  it('sets is_pickup=true when display_time contains "pick-up" (case-insensitive)', () => {
+    const html = buildPage(buildEvent({ title: 'DC:FT', time: 'pick-up ( 9 am - 10 am )' }));
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.is_pickup).toBe(true);
+  });
+
+  // --- Multiple pets ---
+
+  it('extracts all pet IDs and names when an event has multiple pets', () => {
+    const html = buildPage(
+      buildEvent({
+        pets: [
+          { id: 11111, name: 'Chester' },
+          { id: 22222, name: 'Billy' },
+          { id: 33333, name: 'Buddy' },
+        ],
+      })
+    );
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.pet_ids).toEqual([11111, 22222, 33333]);
+    expect(appt.pet_names).toEqual(['Chester', 'Billy', 'Buddy']);
+  });
+
+  // --- Graceful degradation ---
+
+  it('stores the event and still parses when worker uid is unknown', () => {
+    // uid 999999 is not in KNOWN_WORKERS — should warn and still return the event
+    const html = buildPage(buildEvent({ classes: 'day-event ew-999999 cat-5634 ser-10692' }));
+    const results = parseDaytimeSchedulePage(html);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].worker_external_id).toBe(999999);
+  });
+
+  it('skips an event with a missing data-ts and still returns other events on the page', () => {
+    // data-ts="0" → tsToDate returns null → event is skipped
+    const badEvent = buildEvent({ id: 'BADT5', dayTs: 0 });
+    const goodEvent = buildEvent({ id: 'GOODT5' });
+    const html = buildPage(badEvent, goodEvent);
+    const results = parseDaytimeSchedulePage(html);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].external_id).toBe('GOODT5');
+  });
+
+  it('ignores <a data-id> links that are not /schedule/a/ appointment links', () => {
+    // A nav link that happens to carry data-id should be filtered out
+    const navLink = `<a href="/pets/90043/forms" data-id="irrelevant">Pet Forms</a>`;
+    const apptEvent = buildEvent({ id: 'REAL01' });
+    const html = buildPage(navLink, apptEvent);
+    const results = parseDaytimeSchedulePage(html);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].external_id).toBe('REAL01');
+  });
+
+  it('stores series_id as null when data-series is an empty string', () => {
+    const html = buildPage(buildEvent({ series: '' }));
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.series_id).toBeNull();
+  });
+
+  it('stores start_ts as null when data-start is 0', () => {
+    const html = buildPage(buildEvent({ startTs: 0 }));
+    const [appt] = parseDaytimeSchedulePage(html);
+
+    expect(appt.start_ts).toBeNull();
+  });
+});

--- a/src/lib/scraper/daytimeSchedule.js
+++ b/src/lib/scraper/daytimeSchedule.js
@@ -1,0 +1,319 @@
+/**
+ * Daytime schedule parser — ingests all Daycare, Playgroup, and Boarding
+ * appointments from the weekly schedule page for v4 Activity Intelligence.
+ *
+ * No detail-page fetches are needed: the schedule grid exposes all required
+ * fields (worker, service, pets, series ID) directly as data attributes and
+ * child element text on each `.day-event <a>` element.
+ *
+ * Node.js safe: regex-only parsing, no DOMParser. Works in both cron context
+ * and browser/jsdom tests.
+ *
+ * @requirements REQ-v4.0
+ */
+
+import { createSyncLogger } from './logger.js';
+
+const logger = createSyncLogger('DaytimeSched');
+const log = logger.log;
+const logWarn = logger.warn;
+
+// ---------------------------------------------------------------------------
+// Constants — classification tables
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps cat-{id} class number → human-readable service category label.
+ * An event whose cat-id is NOT in this table is still parsed; a warning is
+ * emitted so the constant can be updated when the external site adds services.
+ */
+const SERVICE_CATS = Object.freeze({
+  5634: 'DC',       // Daycare
+  7431: 'PG',       // Playgroup
+  5635: 'Boarding',
+});
+
+/**
+ * Maps ew-{uid} class number → worker name.
+ * Worker uid 0 means no worker assigned (typical for boarding events).
+ * An unknown uid emits a warning but the event is still stored.
+ */
+const KNOWN_WORKERS = Object.freeze({
+  0: null,
+  61023: 'Charlie',
+  208669: 'Kathalyn Dominguez',
+  141407: 'Kentaro Cavey',
+  174385: 'Max Posse',
+  189436: 'Sierra Tagle',
+  164375: 'Stephen Muro',
+});
+
+/** Matches "Pick-Up" variants in title or display_time text. */
+const PICKUP_RE = /pick-?up/i;
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a named HTML attribute value from an attribute string.
+ * The attrStr is the captured attrs portion of a single <a> tag, so
+ * false-positive matches on unrelated attributes are not a concern.
+ *
+ * Error-handling: returns null (not throws) if the attribute is absent.
+ *
+ * @param {string} attrStr - The attribute portion of an <a> tag
+ * @param {string} name    - Exact attribute name, e.g. "data-id"
+ * @returns {string|null}
+ */
+function attr(attrStr, name) {
+  const m = attrStr.match(new RegExp(`${name}="([^"]*)"`));
+  return m ? m[1] : null;
+}
+
+/**
+ * Extract trimmed inner text of the FIRST element with a given CSS class
+ * from an HTML fragment.
+ *
+ * Uses a simple `class="... className ..."` pattern — sufficient for the
+ * known, stable class names on the external site. Returns '' (not null) so
+ * callers can safely call .trim() / boolean-check without null guards.
+ *
+ * Error-handling: returns '' if no match; never throws.
+ *
+ * @param {string} html      - Inner HTML of a day-event block
+ * @param {string} className - CSS class name to search for
+ * @returns {string}
+ */
+function innerText(html, className) {
+  const re = new RegExp(`class="[^"]*\\b${className}\\b[^"]*"[^>]*>([^<]*)<`);
+  const m = html.match(re);
+  return m ? m[1].trim() : '';
+}
+
+/**
+ * Convert a Unix timestamp (seconds) to a YYYY-MM-DD date string.
+ *
+ * data-ts values represent midnight of the day column in Pacific time.
+ * Midnight PT (UTC-7/8) corresponds to 07:00–08:00 UTC the same calendar
+ * date, so toISOString().slice(0,10) always returns the correct local date.
+ *
+ * Error-handling: returns null for falsy or unparseable inputs.
+ *
+ * @param {number} unixSeconds
+ * @returns {string|null}
+ */
+function tsToDate(unixSeconds) {
+  if (!unixSeconds) return null;
+  const d = new Date(unixSeconds * 1000);
+  if (isNaN(d.getTime())) return null;
+  return d.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse all appointments from a weekly schedule page HTML.
+ *
+ * Pure function — no I/O, no side effects. Suitable for unit testing with a
+ * fixture HTML string and no mocking.
+ *
+ * Strategy: match every <a data-id="..."> block (all schedule appointment
+ * links carry data-id). The same external_id may appear in multiple day
+ * columns for multi-day events — this is intentional; each
+ * (external_id, appointment_date) pair maps to a distinct DB row. No
+ * cross-column deduplication is done here; the upsert layer handles that.
+ *
+ * Error-handling strategy: per-event errors skip that event (with a warning)
+ * and never abort the parse. The caller always receives the subset of events
+ * that were successfully parsed.
+ *
+ * @param {string} html - Full weekly schedule page HTML
+ * @returns {Array<Object>} Flat array of appointment objects ready for upsert
+ */
+export function parseDaytimeSchedulePage(html) {
+  const appointments = [];
+
+  // Match every <a> block carrying a data-id attribute.
+  // Appointment links have no nested <a> elements, so non-greedy [\s\S]*? is safe.
+  const blockRe = /<a\b([^>]*\bdata-id="[^"]*"[^>]*)>([\s\S]*?)<\/a>/gi;
+  let m;
+
+  while ((m = blockRe.exec(html)) !== null) {
+    const attrStr = m[1];
+    const inner = m[2];
+
+    // Guard: only process /schedule/a/ appointment links. Other <a data-id>
+    // elements (e.g. nav links) are discarded here.
+    const href = attr(attrStr, 'href') || '';
+    if (!href.includes('/schedule/a/')) continue;
+
+    const externalId = attr(attrStr, 'data-id');
+    if (!externalId) continue;
+
+    // --- Date resolution ---
+    // Decision: data-ts is the day-column's midnight timestamp. If missing or
+    // unparseable, the event cannot be dated → skip and warn.
+    const dayTsRaw = parseInt(attr(attrStr, 'data-ts') || '0', 10);
+    const appointmentDate = tsToDate(dayTsRaw);
+    if (!appointmentDate) {
+      logWarn(`Skipping event ${externalId} — unparseable data-ts: "${attr(attrStr, 'data-ts')}"`);
+      continue;
+    }
+
+    // --- Scalar data attributes ---
+    const seriesId = attr(attrStr, 'data-series') || null;
+    const startTsRaw = parseInt(attr(attrStr, 'data-start') || '0', 10);
+    const status = parseInt(attr(attrStr, 'data-status') || '0', 10);
+    const classes = attr(attrStr, 'class') || '';
+
+    // --- Worker extraction ---
+    // Decision: ew-{uid} class identifies the assigned worker.
+    // uid 0 = no worker (boardings). Unknown uid = warn, still store.
+    const workerMatch = classes.match(/\bew-(\d+)\b/);
+    const workerExternalId = workerMatch ? parseInt(workerMatch[1], 10) : 0;
+    if (workerMatch && !(workerExternalId in KNOWN_WORKERS)) {
+      logWarn(
+        `Unknown worker uid ${workerExternalId} on event ${externalId} (${appointmentDate})` +
+          ' — add to KNOWN_WORKERS constant'
+      );
+    }
+
+    // --- Service classification ---
+    // Decision: cat-{id} and ser-{id} classes carry category and service IDs.
+    // Unknown cat-id → serviceCategory is null but event is still stored; warn.
+    const catMatch = classes.match(/\bcat-(\d+)\b/);
+    const serMatch = classes.match(/\bser-(\d+)\b/);
+    const serviceCatId = catMatch ? parseInt(catMatch[1], 10) : null;
+    const serviceId = serMatch ? parseInt(serMatch[1], 10) : null;
+    const serviceCategory = serviceCatId != null ? (SERVICE_CATS[serviceCatId] ?? null) : null;
+    if (serviceCatId != null && !SERVICE_CATS[serviceCatId]) {
+      logWarn(
+        `Unknown service cat-${serviceCatId} on event ${externalId} — update SERVICE_CATS constant`
+      );
+    }
+
+    // --- Multi-day span flags ---
+    // appt-after = event continues into days after this column → is_multiday_start
+    // appt-before = event started in days before this column  → is_multiday_end
+    const isMultidayStart = /\bappt-after\b/.test(classes);
+    const isMultidayEnd = /\bappt-before\b/.test(classes);
+
+    // --- Inner element text ---
+    const title = innerText(inner, 'day-event-title');
+    const displayTime = innerText(inner, 'day-event-time');
+    const clientName = innerText(inner, 'event-client');
+
+    // client_uid: data-uid on the .event-clients-pets wrapper. The attribute
+    // may appear before or after the class attribute, so scan the inner block
+    // for any data-uid value (only one per event block).
+    const clientUidMatch = inner.match(/data-uid="(\d+)"/);
+    const clientUid = clientUidMatch ? parseInt(clientUidMatch[1], 10) : null;
+
+    // --- Pet IDs and names ---
+    // Pet IDs come from data-pet on .event-pet-wrapper elements.
+    // Pet names come from inner text of .event-pet spans.
+    const petIds = [];
+    const petIdRe = /data-pet="(\d+)"/g;
+    let pw;
+    while ((pw = petIdRe.exec(inner)) !== null) {
+      petIds.push(parseInt(pw[1], 10));
+    }
+
+    const petNames = [];
+    const petNameRe = /class="[^"]*\bevent-pet\b[^"]*"[^>]*>([^<]+)</g;
+    let pn;
+    while ((pn = petNameRe.exec(inner)) !== null) {
+      const name = pn[1].trim();
+      if (name) petNames.push(name);
+    }
+
+    // Decision: zero pet IDs on a non-boarding is unexpected — warn so we can
+    // investigate whether the HTML structure changed.
+    if (petIds.length === 0) {
+      logWarn(`No pet IDs on event ${externalId} (${appointmentDate}, cat-${serviceCatId})`);
+    }
+
+    const isPickup = PICKUP_RE.test(title) || PICKUP_RE.test(displayTime);
+
+    appointments.push({
+      external_id: externalId,
+      series_id: seriesId,
+      appointment_date: appointmentDate,
+      worker_external_id: workerExternalId,
+      service_category: serviceCategory,
+      service_cat_id: serviceCatId,
+      service_id: serviceId,
+      title: title || null,
+      status,
+      start_ts: startTsRaw || null,
+      day_ts: dayTsRaw || null,
+      display_time: displayTime || null,
+      client_uid: clientUid,
+      client_name: clientName || null,
+      pet_ids: petIds,
+      pet_names: petNames,
+      is_pickup: isPickup,
+      is_multiday_start: isMultidayStart,
+      is_multiday_end: isMultidayEnd,
+    });
+  }
+
+  log(`Parsed ${appointments.length} appointments from schedule HTML`);
+  return appointments;
+}
+
+/**
+ * Upsert a batch of daytime appointments into the daytime_appointments table.
+ *
+ * Strategy: deduplicate the input batch by (external_id, appointment_date)
+ * before sending — prevents Supabase errors when two fetched pages overlap on
+ * the same week and return the same event twice. Last occurrence wins.
+ *
+ * onConflict='external_id,appointment_date' means a re-sync of the same day
+ * updates status/times/pets in place rather than inserting a duplicate row.
+ *
+ * Error-handling: a Supabase-level error is logged and reported in the return
+ * value; it does NOT throw so the cron caller can decide whether to treat it
+ * as fatal.
+ *
+ * @param {Object} supabase              - Supabase client (service-role for cron)
+ * @param {Array<Object>} appointments   - Output from parseDaytimeSchedulePage
+ * @returns {Promise<{ upserted: number, errors: number }>}
+ */
+export async function upsertDaytimeAppointments(supabase, appointments) {
+  // Decision: nothing to do → skip the DB round-trip entirely.
+  if (appointments.length === 0) {
+    log('No daytime appointments to upsert — skipping');
+    return { upserted: 0, errors: 0 };
+  }
+
+  // Deduplicate by composite key; last occurrence wins (more recent parse data).
+  const seen = new Map();
+  for (const appt of appointments) {
+    seen.set(`${appt.external_id}|${appt.appointment_date}`, appt);
+  }
+  const deduped = Array.from(seen.values());
+
+  if (deduped.length < appointments.length) {
+    log(`Deduped ${appointments.length} → ${deduped.length} before upsert`);
+  }
+
+  log(`Upserting ${deduped.length} daytime appointments`);
+
+  const { error } = await supabase
+    .from('daytime_appointments')
+    .upsert(deduped, { onConflict: 'external_id,appointment_date' });
+
+  if (error) {
+    // Decision: log details for diagnosis; return error count so the cron
+    // health record captures the failure without crashing the whole cron run.
+    logWarn(`Upsert failed — ${error.message} (code: ${error.code})`);
+    return { upserted: 0, errors: deduped.length };
+  }
+
+  log(`Upserted ${deduped.length} daytime appointments`);
+  return { upserted: deduped.length, errors: 0 };
+}

--- a/supabase/migrations/018_add_daytime_tables.sql
+++ b/supabase/migrations/018_add_daytime_tables.sql
@@ -1,0 +1,100 @@
+-- v4.0 Daytime Activity Intelligence
+--
+-- Two new tables:
+--   workers            — known staff members, seeded from KNOWN_WORKERS constant
+--   daytime_appointments — all DC/PG/Boarding events from the weekly schedule grid
+--
+-- No detail-page fetches are needed; all fields come from data attributes and
+-- child element text on the .day-event <a> elements in the schedule HTML.
+
+-- ---------------------------------------------------------------------------
+-- workers
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS workers (
+  id          SERIAL PRIMARY KEY,
+  external_id INTEGER UNIQUE NOT NULL,  -- ew-{uid} class value, e.g. 61023
+  name        TEXT NOT NULL,
+  active      BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed known workers (matches KNOWN_WORKERS constant in daytimeSchedule.js).
+-- ON CONFLICT DO NOTHING so re-running is safe.
+INSERT INTO workers (external_id, name) VALUES
+  (61023,  'Charlie'),
+  (208669, 'Kathalyn Dominguez'),
+  (141407, 'Kentaro Cavey'),
+  (174385, 'Max Posse'),
+  (189436, 'Sierra Tagle'),
+  (164375, 'Stephen Muro')
+ON CONFLICT (external_id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- daytime_appointments
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS daytime_appointments (
+  id                  SERIAL PRIMARY KEY,
+
+  -- Identity
+  external_id         TEXT        NOT NULL,           -- data-id, e.g. "C63QgUnJ"
+  series_id           TEXT,                           -- data-series, stable for recurring appts
+  appointment_date    DATE        NOT NULL,           -- derived from data-ts (day-column midnight)
+
+  -- Worker / service
+  worker_external_id  INTEGER,                        -- ew-{uid}; 0 = no worker (boardings)
+  service_category    TEXT,                           -- 'DC', 'PG', 'Boarding', or NULL if unknown
+  service_cat_id      INTEGER,                        -- e.g. 5634
+  service_id          INTEGER,                        -- e.g. 10692
+
+  -- Display fields
+  title               TEXT,                           -- .day-event-title inner text
+  status              INTEGER,                        -- 1=upcoming, 5=in-progress, 6=completed
+  start_ts            BIGINT,                         -- data-start (Unix seconds, actual check-in)
+  day_ts              BIGINT,                         -- data-ts  (Unix seconds, midnight of column)
+  display_time        TEXT,                           -- .day-event-time inner text
+
+  -- Client / pets
+  client_uid          INTEGER,
+  client_name         TEXT,
+  pet_ids             INTEGER[],                      -- data-pet values from .event-pet-wrapper
+  pet_names           TEXT[],
+
+  -- Flags
+  is_pickup           BOOLEAN     NOT NULL DEFAULT FALSE,  -- title/time contains "Pick-Up"
+  is_multiday_start   BOOLEAN     NOT NULL DEFAULT FALSE,  -- has class appt-after
+  is_multiday_end     BOOLEAN     NOT NULL DEFAULT FALSE,  -- has class appt-before
+
+  -- Housekeeping
+  synced_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- The same external_id can legitimately appear on multiple day columns
+  -- (multi-day spanning events). Each (external_id, appointment_date) pair
+  -- is distinct and re-syncing the same day updates the row in place.
+  UNIQUE (external_id, appointment_date)
+);
+
+-- Primary access pattern: "all events for a given date, grouped by worker"
+CREATE INDEX IF NOT EXISTS daytime_appts_date_worker_idx
+  ON daytime_appointments (appointment_date, worker_external_id);
+
+-- Series lookup: "what series IDs were present on day N for diff computation"
+CREATE INDEX IF NOT EXISTS daytime_appts_series_idx
+  ON daytime_appointments (series_id)
+  WHERE series_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- RLS — service-role key (cron) bypasses RLS; anon key reads allowed
+-- ---------------------------------------------------------------------------
+ALTER TABLE workers               ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daytime_appointments  ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users (app) can read both tables
+CREATE POLICY "Authenticated read workers"
+  ON workers FOR SELECT
+  TO authenticated
+  USING (TRUE);
+
+CREATE POLICY "Authenticated read daytime_appointments"
+  ON daytime_appointments FOR SELECT
+  TO authenticated
+  USING (TRUE);


### PR DESCRIPTION
## Summary

- New `src/lib/scraper/daytimeSchedule.js` — pure regex parser (`parseDaytimeSchedulePage`) + upsert helper (`upsertDaytimeAppointments`) for all DC/PG/Boarding events on the weekly schedule grid
- Updated `api/cron-schedule.js` — pipes existing fetched HTML through the daytime parser after each page fetch; no additional network requests
- New migration `018_add_daytime_tables.sql` — creates `workers` (seeded) and `daytime_appointments` tables with appropriate indexes and RLS policies
- 19 new tests covering field extraction, service classification, multi-day spans, pick-up detection, multi-pet events, and graceful degradation for unknown worker/service IDs and missing timestamps

## Before merging
- Apply `supabase/migrations/018_add_daytime_tables.sql` in Supabase SQL editor

## Test plan
- [x] 711 tests, 0 failures (`npx vitest run`)
- [x] All 59 enforced requirements covered (pre-commit hook passed)
- [ ] Apply migration 018 in Supabase
- [ ] Verify cron-schedule health record includes `daytimeUpserted` after next cron run