### PR TITLE
chore: update cron schedules for PDT (March DST)

### DIFF
--- a/.github/workflows/notify-4am.yml
+++ b/.github/workflows/notify-4am.yml
@@ -7,8 +7,8 @@ name: Notify 4am PST
 
 on:
   schedule:
-    # 12:00 UTC = 4am PST (standard time, Nov–Mar)
-    - cron: '0 12 * * *'
+    # 11:00 UTC = 4am PDT (daylight time, Mar–Nov)
+    - cron: '0 11 * * *'
   workflow_dispatch:  # Allow manual trigger for testing
 
 jobs:

--- a/.github/workflows/notify-7am.yml
+++ b/.github/workflows/notify-7am.yml
@@ -4,8 +4,8 @@ name: Notify 7am PST
 
 on:
   schedule:
-    # 15:00 UTC = 7am PST (standard time, Nov–Mar)
-    - cron: '0 15 * * *'
+    # 14:00 UTC = 7am PDT (daylight time, Mar–Nov)
+    - cron: '0 14 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/notify-830am.yml
+++ b/.github/workflows/notify-830am.yml
@@ -4,8 +4,8 @@ name: Notify 8:30am PST
 
 on:
   schedule:
-    # 16:30 UTC = 8:30am PST (standard time, Nov–Mar)
-    - cron: '30 16 * * *'
+    # 15:30 UTC = 8:30am PDT (daylight time, Mar–Nov)
+    - cron: '30 15 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- DST starts March 8, 2026 (PST → PDT, UTC-8 → UTC-7)
- Shift all three notify workflows back 1 hour in UTC

| Workflow | Old cron | New cron | Wall clock |
|---|---|---|---|
| notify-4am | `0 12 * * *` | `0 11 * * *` | 4am PDT |
| notify-7am | `0 15 * * *` | `0 14 * * *` | 7am PDT |
| notify-830am | `30 16 * * *` | `30 15 * * *` | 8:30am PDT |

No code changes — cron schedule lines + comments only.