### PR TITLE
fix: skip sync step by default, document DOMParser/timeout issue (#53)

### DIFF
--- a/.github/workflows/integration-check.yml
+++ b/.github/workflows/integration-check.yml
@@ -1,5 +1,8 @@
-# Integration check — triggers a live sync, then scrapes the AGYD schedule via
-# real browser + Claude vision, compares against DB, sends WhatsApp report.
+# Integration check — scrapes the AGYD schedule via real browser + Claude vision,
+# compares against DB, sends WhatsApp report.
+#
+# Step 0 (sync) is currently disabled — see SKIP_SYNC note in integration-check.js.
+# Set skip_sync=false on a manual run to attempt sync (will likely fail until fixed).
 #
 # Runs 3x/day. Also available on-demand via workflow_dispatch.
 #
@@ -16,6 +19,11 @@ name: Integration Check
 
 on:
   workflow_dispatch:
+    inputs:
+      skip_sync:
+        description: 'Skip Step 0 sync (set false to attempt sync — currently broken)'
+        required: false
+        default: 'true'
   schedule:
     # 1:00 AM PDT (08:00 UTC) — shortly after midnight cron finishes
     - cron: '0 8 * * *'
@@ -54,3 +62,5 @@ jobs:
           INTEGRATION_CHECK_RECIPIENTS: ${{ secrets.INTEGRATION_CHECK_RECIPIENTS }}
           APP_URL: ${{ secrets.APP_URL }}
           VITE_SYNC_PROXY_TOKEN: ${{ secrets.VITE_SYNC_PROXY_TOKEN }}
+          # Scheduled runs always skip sync. Manual runs can override via the input.
+          SKIP_SYNC: ${{ github.event.inputs.skip_sync || 'true' }}

--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -495,21 +495,38 @@ async function main() {
 
   const appUrl = process.env.APP_URL;
   const syncToken = process.env.VITE_SYNC_PROXY_TOKEN;
-  if (!appUrl || !syncToken) {
-    const msg = `⚠️ Integration check crashed at startup (${today}): Missing APP_URL or VITE_SYNC_PROXY_TOKEN`;
-    console.error('[IntegCheck]', msg);
-    await sendWhatsApp(twilioClient, msg);
-    process.exit(1);
-  }
 
-  // Step 0: Sync — must succeed before we compare, or we risk a false pass on stale data
-  try {
-    await triggerSync(appUrl, syncToken);
-  } catch (err) {
-    const msg = `⚠️ Integration check aborted (${today})\nSync failed: ${err.message}`;
-    console.error('[IntegCheck]', msg);
-    await sendWhatsApp(twilioClient, msg);
-    process.exit(1);
+  // Step 0: Sync (currently disabled — SKIP_SYNC=true in workflow)
+  //
+  // KNOWN ISSUE: api/run-sync.js calls runSync() from sync.js, which calls
+  // fetchAllSchedulePages() from schedule.js. That file uses DOMParser — a
+  // browser API unavailable in Vercel's Node.js runtime. Additionally, the
+  // Vercel Hobby plan 10s timeout is too short for a full sync.
+  //
+  // TODO: Fix by either:
+  //   A) Having run-sync.js call the existing cron endpoints via HTTP
+  //      (cron-schedule + cron-detail loop) instead of runSync() directly.
+  //      Requires CRON_SECRET as a GH repo secret.
+  //   B) Removing this step entirely — the check is a verifier, not a syncer.
+  //      If the midnight cron is broken, missing boardings will surface here anyway.
+  const skipSync = process.env.SKIP_SYNC === 'true';
+  if (skipSync) {
+    console.log('[IntegCheck] Step 0: skipped (SKIP_SYNC=true)');
+  } else {
+    if (!appUrl || !syncToken) {
+      const msg = `⚠️ Integration check crashed at startup (${today}): Missing APP_URL or VITE_SYNC_PROXY_TOKEN`;
+      console.error('[IntegCheck]', msg);
+      await sendWhatsApp(twilioClient, msg);
+      process.exit(1);
+    }
+    try {
+      await triggerSync(appUrl, syncToken);
+    } catch (err) {
+      const msg = `⚠️ Integration check aborted (${today})\nSync failed: ${err.message}`;
+      console.error('[IntegCheck]', msg);
+      await sendWhatsApp(twilioClient, msg);
+      process.exit(1);
+    }
   }
 
   // Step 1: Session


### PR DESCRIPTION
## Summary
- Step 0 (sync trigger) is broken — api/run-sync.js calls runSync() which uses DOMParser (browser-only, unavailable in Vercel Node.js runtime). Vercel Hobby 10s timeout also too short for a full sync.
- Added SKIP_SYNC env var — when true, Step 0 is skipped with a log line
- Workflow defaults SKIP_SYNC=true for both scheduled and manual runs
- workflow_dispatch now has a skip_sync input (default true) to toggle when Step 0 is eventually fixed
- TODO comment documents the two fix paths (call cron endpoints via HTTP, or remove sync step entirely)

## Test plan
- [ ] 742 tests pass
- [ ] Manual run with default input — Step 0 logged as skipped, check proceeds to Playwright
