### PR TITLE
fix: handle request and canceled-request appointment types (#64)

### DIFF
--- a/src/__tests__/scraper/extraction.test.js
+++ b/src/__tests__/scraper/extraction.test.js
@@ -16,6 +16,8 @@ import {
   mockPricingDecimalTotal,
   mockPricingNoPriceDivs,
   mockPricingMultiPet,
+  mockRequestCanceledPage,
+  mockPendingRequestPage,
 } from './fixtures.js';
 
 describe('REQ-102: Appointment Detail Extraction', () => {
@@ -525,5 +527,29 @@ describe('extractCheckInOutAmPm()', () => {
 
   it('returns nulls when neither block is present', () => {
     expect(extractCheckInOutAmPm('<div>no time info</div>')).toEqual({ checkInAmPm: null, checkOutAmPm: null });
+  });
+});
+
+describe('booking_status extraction', () => {
+  it('returns "confirmed" for a normal appointment (no .event-status div)', () => {
+    const data = parseAppointmentPage(mockAppointmentPage);
+    expect(data.booking_status).toBe('confirmed');
+  });
+
+  it('returns "canceled" for a Request canceled appointment', () => {
+    const data = parseAppointmentPage(mockRequestCanceledPage);
+    expect(data.booking_status).toBe('canceled');
+  });
+
+  it('returns "pending" for a Request (not yet confirmed) appointment', () => {
+    const data = parseAppointmentPage(mockPendingRequestPage);
+    expect(data.booking_status).toBe('pending');
+  });
+
+  it('still extracts dates and service type from a canceled-request page', () => {
+    const data = parseAppointmentPage(mockRequestCanceledPage);
+    expect(data.booking_status).toBe('canceled');
+    expect(data.check_in_datetime).toBe('2026-03-12T10:00:00.000Z');
+    expect(data.check_out_datetime).toBe('2026-03-17T16:15:00.000Z');
   });
 });

--- a/src/__tests__/scraper/fixtures.js
+++ b/src/__tests__/scraper/fixtures.js
@@ -463,6 +463,89 @@ export const mockExternalAppointmentSingleLinePricing = {
   },
 };
 
+// Minimal detail page for a "Request canceled" appointment (e.g. C63QgSdB).
+// The .event-status div signals the appointment was never confirmed.
+// Verified against real AGYD HTML (2026-03-17).
+export const mockRequestCanceledPage = `
+<!DOCTYPE html>
+<html>
+<head><title>Boarding (Nights) | A Girl and Your Dog</title></head>
+<body>
+  <div class="events-view es-9 et-1">
+    <div class="event-status"><div class="field-value">Request canceled</div></div>
+    <div class="appt-info">
+      <div class="dt-row" id="services-wrapper">
+        <div class="field-value" data-id="17357" data-cat_id="5635">
+          <a class="service-link" href="/services/categories/5635?view_id=17357">Boarding (Nights)</a>
+        </div>
+      </div>
+      <div class="dt-row" id="when-wrapper"
+           data-start_scheduled="1773309600" data-end_scheduled="1773764100"
+           data-start_actual="1773309600" data-end_actual="1773764100">
+        <div class="field-value">
+          <span class="time the start"><span class="time-label" title="">AM</span>, </span>
+          <span class="time time-date">Thursday, March 12, 2026</span>
+          <span class="time the"><span class="time-label" title="">PM</span>, </span>
+          <span class="time time-date">Tuesday, March 17, 2026</span>
+        </div>
+      </div>
+      <div class="cancel_at" data-cancel_by="91854" data-cancel_at="1772565535">Canceled at: 3/3/2026</div>
+    </div>
+    <div class="appt-clients-pets">
+      <div class="event-clients-pets" id="events-clients-pets-91854" data-uid="91854">
+        <a href="/clients/91854" class="event-client">Cathy Price</a>
+        <div class="event-pets pets-count-1" data-pets="77457">
+          <div class="event-pet-wrapper" data-pet="77457">
+            <a href="/pets/77457" class="event-pet pet-77457" data-pet="77457">Olive Price</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+`;
+
+// Minimal detail page for a "Request" (pending, not yet confirmed or canceled).
+export const mockPendingRequestPage = `
+<!DOCTYPE html>
+<html>
+<head><title>Boarding (Nights) | A Girl and Your Dog</title></head>
+<body>
+  <div class="events-view es-2 et-1">
+    <div class="event-status"><div class="field-value">Request</div></div>
+    <div class="appt-info">
+      <div class="dt-row" id="services-wrapper">
+        <div class="field-value" data-id="17357" data-cat_id="5635">
+          <a class="service-link" href="/services/categories/5635?view_id=17357">Boarding (Nights)</a>
+        </div>
+      </div>
+      <div class="dt-row" id="when-wrapper"
+           data-start_scheduled="1773309600" data-end_scheduled="1773764100"
+           data-start_actual="1773309600" data-end_actual="1773764100">
+        <div class="field-value">
+          <span class="time the start"><span class="time-label" title="">AM</span>, </span>
+          <span class="time time-date">Thursday, March 12, 2026</span>
+          <span class="time the"><span class="time-label" title="">PM</span>, </span>
+          <span class="time time-date">Tuesday, March 17, 2026</span>
+        </div>
+      </div>
+    </div>
+    <div class="appt-clients-pets">
+      <div class="event-clients-pets" id="events-clients-pets-91854" data-uid="91854">
+        <a href="/clients/91854" class="event-client">Cathy Price</a>
+        <div class="event-pets pets-count-1" data-pets="77457">
+          <div class="event-pet-wrapper" data-pet="77457">
+            <a href="/pets/77457" class="event-pet pet-77457" data-pet="77457">Olive Price</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+`;
+
 export const mockSyncLog = {
   id: 'test-sync-1',
   started_at: '2025-12-20T10:00:00Z',

--- a/src/components/BoardingMatrix.jsx
+++ b/src/components/BoardingMatrix.jsx
@@ -138,24 +138,27 @@ export default function BoardingMatrix({ startDate, days = DEFAULT_MATRIX_DAYS }
 
     let isDay = false;
     let isNight = false;
+    let isPending = false;
 
     for (const boarding of dogBoardings) {
       if (isDayPresent(boarding, dateStr)) {
         isDay = true;
+        if (boarding.bookingStatus === 'pending') isPending = true;
       }
       if (isOvernight(boarding, dateStr)) {
         isNight = true;
+        if (boarding.bookingStatus === 'pending') isPending = true;
       }
     }
 
     if (isNight) {
-      return (
-        <div className="w-7 h-7 mx-auto rounded-lg bg-gradient-to-br from-indigo-500 to-indigo-600 shadow-sm" title="Overnight" />
-      );
+      return isPending
+        ? <div className="w-7 h-7 mx-auto rounded-lg border-2 border-indigo-400 bg-indigo-50" title="Pending overnight request" />
+        : <div className="w-7 h-7 mx-auto rounded-lg bg-gradient-to-br from-indigo-500 to-indigo-600 shadow-sm" title="Overnight" />;
     } else if (isDay) {
-      return (
-        <div className="w-7 h-7 mx-auto rounded-lg bg-gradient-to-br from-amber-400 to-amber-500 shadow-sm" title="Day only" />
-      );
+      return isPending
+        ? <div className="w-7 h-7 mx-auto rounded-lg border-2 border-amber-400 bg-amber-50" title="Pending day request" />
+        : <div className="w-7 h-7 mx-auto rounded-lg bg-gradient-to-br from-amber-400 to-amber-500 shadow-sm" title="Day only" />;
     }
     return <span className="text-slate-300">—</span>;
   };

--- a/src/hooks/useBoardings.js
+++ b/src/hooks/useBoardings.js
@@ -36,6 +36,7 @@ export function useBoardings() {
         nightRate: b.night_rate != null ? parseFloat(b.night_rate) : null,
         billedAmount: b.billed_amount != null ? parseFloat(b.billed_amount) : null,
         source: b.source ?? null,
+        bookingStatus: b.booking_status ?? 'confirmed',
       })));
     } catch (err) {
       console.error('Error fetching boardings:', err);

--- a/src/lib/scraper/extraction.js
+++ b/src/lib/scraper/extraction.js
@@ -110,6 +110,7 @@ export function parseAppointmentPage(html, sourceUrl = '') {
     // Appointment info
     service_type: serviceType,
     status: extractText(html, SCRAPER_CONFIG.selectors.status),
+    booking_status: extractEventStatus(html),
     scheduled_check_in: null,
     scheduled_check_out: null,
     check_in_datetime: checkInDatetime,
@@ -284,6 +285,26 @@ function extractAddressFromDataAttr(html) {
 function extractDuration(html) {
   const match = html.match(/class="scheduled-duration"[^>]*>\(Scheduled:\s*([^)]+)\)/);
   return match ? match[1].trim() : null;
+}
+
+/**
+ * Extract booking status from the .event-status block on the detail page.
+ *
+ * The external site renders an .event-status div only for non-confirmed appointments:
+ *   <div class="event-status"><div class="field-value">Request canceled</div></div>
+ *
+ * Returns:
+ *   'canceled' — status text contains "cancel" (request was never confirmed)
+ *   'pending'  — status text contains "request" but not "cancel" (awaiting confirmation)
+ *   'confirmed' — no .event-status div present (normal confirmed booking)
+ */
+function extractEventStatus(html) {
+  const match = html.match(/class="event-status">\s*<div[^>]*>\s*([^<]+?)\s*<\/div>/i);
+  if (!match) return 'confirmed';
+  const text = match[1].trim();
+  if (/cancel/i.test(text)) return 'canceled';
+  if (/request/i.test(text)) return 'pending';
+  return 'confirmed';
 }
 
 /**

--- a/src/lib/scraper/mapping.js
+++ b/src/lib/scraper/mapping.js
@@ -93,9 +93,10 @@ export function mapToBoarding(externalData, dogId) {
     departure_ampm: externalData.check_out_ampm ?? null,
     source: 'external',
     external_id: externalData.external_id,
-    billed_amount: pricing ? pricing.total : null,
-    night_rate:    nightItem ? nightItem.rate : null,
-    day_rate:      dayItem   ? dayItem.rate   : null,
+    billed_amount:  pricing ? pricing.total : null,
+    night_rate:     nightItem ? nightItem.rate : null,
+    day_rate:       dayItem   ? dayItem.rate   : null,
+    booking_status: externalData.booking_status ?? 'confirmed',
   };
 }
 
@@ -463,6 +464,7 @@ export async function upsertBoarding(supabase, boardingData) {
     if ('day_rate'      in boardingData) updateFields.day_rate      = boardingData.day_rate;
     if (boardingData.arrival_ampm   != null) updateFields.arrival_ampm   = boardingData.arrival_ampm;
     if (boardingData.departure_ampm != null) updateFields.departure_ampm = boardingData.departure_ampm;
+    if (boardingData.booking_status != null) updateFields.booking_status = boardingData.booking_status;
     mappingLogger.log(
       `[Mapping] Updating boarding ${existing.id} (${boardingData.external_id}) —`,
       `billed=$${updateFields.billed_amount ?? 'null'},`,

--- a/src/lib/scraper/sync.js
+++ b/src/lib/scraper/sync.js
@@ -423,6 +423,15 @@ export async function runSync(options = {}) {
           }
         }
 
+        // Layer 3b: Filter canceled booking requests.
+        // "Request canceled" appointments have booking_status='canceled' — the client
+        // submitted a request that was never confirmed. Skip silently; do not save as boardings.
+        if (details.booking_status === 'canceled') {
+          syncLog(`[Sync] ⏭️ Skipping canceled-request appointment ${appt.id} (status: "${details.booking_status}")`);
+          result.appointmentsSkipped++;
+          continue;
+        }
+
         // Post-fetch pricing filter: catch appointments that passed title filters but whose
         // pricing reveals they are not client boardings:
         //   - All day services (e.g. "Daycare Add-On Day") → title looked like a date range

--- a/supabase/migrations/020_add_booking_status.sql
+++ b/supabase/migrations/020_add_booking_status.sql
@@ -1,0 +1,5 @@
+-- Add booking_status column to boardings table.
+-- Tracks whether a boarding is a confirmed booking, a pending client request,
+-- or should have been skipped (defensive: canceleds are filtered in sync.js before insert).
+-- Default 'confirmed' ensures all existing records are treated as confirmed.
+ALTER TABLE boardings ADD COLUMN IF NOT EXISTS booking_status TEXT DEFAULT 'confirmed';


### PR DESCRIPTION
## Summary

- **Root cause:** AGYD `.event-status` div ("Request canceled" / "Request") was never extracted — canceled and pending requests were saved as regular confirmed boardings.
- Add `extractEventStatus()` in `extraction.js` — returns `confirmed`, `pending`, or `canceled`
- Add `booking_status` field to `parseAppointmentPage()` return object
- Layer 3b filter in `sync.js`: skip `booking_status === canceled` before saving
- Write `booking_status` on insert + update in `mapping.js`
- `useBoardings.js` exposes `bookingStatus` in the app transform
- `BoardingMatrix.jsx`: pending bookings show outlined indicators; confirmed = solid dot
- HTML fixtures added for request-canceled and pending-request pages
- 4 targeted booking_status extraction tests; 746 tests pass
- **Data fix:** deleted mis-saved C63QgSdB (Olive Price, Request canceled, billed $300)

## MIGRATION REQUIRED before deploy

Apply in Supabase dashboard SQL editor:

    ALTER TABLE boardings ADD COLUMN IF NOT EXISTS booking_status TEXT DEFAULT 'confirmed';

File: supabase/migrations/020_add_booking_status.sql
All existing records default to confirmed — no backfill needed.

## Test plan
- [x] booking_status returns confirmed for normal appointment
- [x] booking_status returns canceled for Request canceled page
- [x] booking_status returns pending for Request page
- [x] dates still extracted correctly from canceled-request page
- [x] 746/746 tests pass
- [x] C63QgSdB deleted from boardings (verified via direct DB query)
