### PR TITLE
feat: Friday PM weekend boarding notify (v4.4) (#70)

### DIFF
--- a/.github/workflows/notify-friday-pm.yml
+++ b/.github/workflows/notify-friday-pm.yml
@@ -1,0 +1,28 @@
+# Sends the weekend boarding preview at 3pm PDT every Friday.
+# Shows arrivals + departures for Fri–Sun so Kate has a heads-up before the weekend.
+# DST note: Pacific Daylight Time = UTC-7 (3pm PDT = 22:00 UTC, Mar–Nov).
+#           Pacific Standard Time  = UTC-8 (3pm PST = 23:00 UTC, Nov–Mar).
+#           Update the cron below each March and November DST transition.
+name: Notify Friday PM (Weekend Boarding)
+
+on:
+  schedule:
+    # 22:00 UTC = 3pm PDT (daylight time, Mar–Nov) — Fridays only
+    - cron: '0 22 * * 5'
+  workflow_dispatch:  # Allow manual trigger for testing
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Send weekend boarding preview
+        run: |
+          RESPONSE=$(curl -s -o /tmp/notify_response.json -w "%{http_code}" \
+            "${{ secrets.APP_URL }}/api/notify?window=friday-pm&token=${{ secrets.VITE_SYNC_PROXY_TOKEN }}")
+          echo "HTTP status: $RESPONSE"
+          cat /tmp/notify_response.json
+          if [ "$RESPONSE" != "200" ]; then
+            echo "Notify endpoint returned non-200 status"
+            exit 1
+          fi

--- a/api/notify.js
+++ b/api/notify.js
@@ -40,7 +40,7 @@ import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from '../src/lib/
 
 export const config = { runtime: 'nodejs' };
 
-const VALID_WINDOWS = ['4am', '7am', '8:30am'];
+const VALID_WINDOWS = ['4am', '7am', '8:30am', 'friday-pm'];
 const BASE_URL = process.env.VITE_EXTERNAL_SITE_URL || 'https://agirlandyourdog.com';
 
 // ---------------------------------------------------------------------------
@@ -222,6 +222,49 @@ export default async function handler(req, res) {
     return res.status(400).json({
       error: `Invalid window: "${window}". Must be one of: ${VALID_WINDOWS.join(', ')}`,
     });
+  }
+
+  // --- friday-pm: distinct path — no hash gate, no getPictureOfDay ---
+  if (window === 'friday-pm') {
+    try {
+      const protocol = req.headers['x-forwarded-proto'] || 'https';
+      const host = req.headers['x-forwarded-host'] || req.headers.host;
+      const imageUrl = `${protocol}://${host}/api/roster-image?type=weekend&token=${expectedToken}`;
+      console.log(`[Notify] friday-pm — image URL: ${protocol}://${host}/api/roster-image?type=weekend&token=***`);
+
+      const recipients = getRecipients();
+      if (recipients.length === 0) {
+        console.warn('[Notify] NOTIFY_RECIPIENTS not configured — send skipped');
+        return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_recipients', window });
+      }
+      const fromNumber = process.env.TWILIO_FROM_NUMBER;
+      if (!fromNumber) {
+        console.warn('[Notify] TWILIO_FROM_NUMBER not configured — send skipped');
+        return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_from_number', window });
+      }
+
+      const supabase = getSupabase();
+      const twilioClient = createTwilioClient();
+      console.log(`[Notify] Sending weekend roster to ${recipients.length} recipient(s)`);
+      const sendResults = await sendRosterImage(twilioClient, imageUrl, recipients, fromNumber);
+      await writeCronHealth(supabase, 'notify-friday-pm', 'success', {
+        sentAt: new Date().toISOString(),
+        recipients: sendResults.map(r => r.to),
+        results: sendResults,
+      }, null);
+
+      const sentCount = sendResults.filter(r => r.status === 'sent').length;
+      const failedCount = sendResults.filter(r => r.status === 'failed').length;
+      console.log(`[Notify] friday-pm complete — ${sentCount} sent, ${failedCount} failed`);
+      return res.status(200).json({ ok: true, action: 'sent', window, sentCount, failedCount, results: sendResults });
+    } catch (err) {
+      console.error('[Notify] ❌ friday-pm error:', err.message, err.stack);
+      try {
+        const supabase = getSupabase();
+        await writeCronHealth(supabase, 'notify-friday-pm', 'failure', null, err.message.slice(0, 500));
+      } catch { /* ignore */ }
+      return res.status(500).json({ error: err.message });
+    }
   }
 
   // --- Input validation: date param (defaults to today) ---

--- a/api/roster-image.js
+++ b/api/roster-image.js
@@ -433,6 +433,275 @@ function buildLayout(data) {
 }
 
 // ---------------------------------------------------------------------------
+// Weekend image — data + layout
+// ---------------------------------------------------------------------------
+
+const WEEKEND_SECTION_HEADER_H = 36;
+const WEEKEND_BOARDING_ROW_H = 30;
+const WEEKEND_SECTION_MARGIN = 20;
+
+/**
+ * Return { start, end } ISO strings for the "this weekend" query window.
+ * start = now. end = Monday noon UTC — safely past Sunday 11:59 PM PDT/PST.
+ *
+ * On Fri UTC: +3 days to Monday. On Sat: +2. On Sun: +1.
+ * Falls back to +3 for any other day (manual trigger on non-weekend day).
+ */
+function getWeekendWindowISO() {
+  const now = new Date();
+  const utcDay = now.getUTCDay(); // 0=Sun, 5=Fri, 6=Sat
+  const daysToMonday = utcDay === 6 ? 2 : utcDay === 0 ? 1 : 3;
+  const end = new Date(now);
+  end.setUTCDate(now.getUTCDate() + daysToMonday);
+  end.setUTCHours(12, 0, 0, 0); // Monday noon UTC — past Sunday midnight PDT
+  const displaySun = new Date(now);
+  displaySun.setUTCDate(now.getUTCDate() + daysToMonday - 1);
+  return { start: now.toISOString(), end: end.toISOString(), displayFri: now, displaySun };
+}
+
+/**
+ * Query boardings that arrive OR depart within the weekend window.
+ * Returns { arriving, departing } — a boarding can appear in both if it
+ * arrives and departs within the window (e.g. Fri arrival, Sun departure).
+ */
+async function getWeekendBoardings(supabase, start, end) {
+  console.log(`[RosterImage/Weekend] Querying boardings from ${start} to ${end}`);
+  const { data, error } = await supabase
+    .from('boardings')
+    .select('external_id, arrival_datetime, departure_datetime, client_name, booking_status, dogs(name)')
+    .or(`and(arrival_datetime.gte.${start},arrival_datetime.lte.${end}),and(departure_datetime.gte.${start},departure_datetime.lte.${end})`)
+    .order('arrival_datetime', { ascending: true });
+
+  if (error) throw error;
+
+  const rows = (data || []).map(b => ({
+    external_id: b.external_id,
+    arrival_datetime: b.arrival_datetime,
+    departure_datetime: b.departure_datetime,
+    client_name: b.client_name ?? '',
+    booking_status: b.booking_status ?? 'confirmed',
+    dog_name: b.dogs?.name ?? 'Unknown',
+  }));
+
+  const arriving = rows
+    .filter(b => b.arrival_datetime >= start && b.arrival_datetime <= end)
+    .sort((a, b) => a.arrival_datetime.localeCompare(b.arrival_datetime));
+
+  const departing = rows
+    .filter(b => b.departure_datetime >= start && b.departure_datetime <= end)
+    .sort((a, b) => a.departure_datetime.localeCompare(b.departure_datetime));
+
+  console.log(`[RosterImage/Weekend] ${arriving.length} arriving, ${departing.length} departing`);
+  return { arriving, departing };
+}
+
+/**
+ * Format a UTC ISO datetime as "Fri 3:00 PM" in America/Los_Angeles.
+ */
+function formatWeekendDatetime(isoStr) {
+  if (!isoStr) return '—';
+  const d = new Date(isoStr);
+  if (isNaN(d.getTime())) return '—';
+  const weekday = d.toLocaleDateString('en-US', { timeZone: 'America/Los_Angeles', weekday: 'short' });
+  const time = d.toLocaleTimeString('en-US', {
+    timeZone: 'America/Los_Angeles',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  return `${weekday} ${time}`; // "Fri 3:00 PM"
+}
+
+/**
+ * Format the weekend header date range: "Fri Mar 17 – Sun Mar 19"
+ */
+function formatWeekendHeaderDates(displayFri, displaySun) {
+  const fmt = (d) => d
+    .toLocaleDateString('en-US', {
+      timeZone: 'America/Los_Angeles',
+      weekday: 'short', month: 'short', day: 'numeric',
+    })
+    .replace(',', '');
+  return `${fmt(displayFri)} – ${fmt(displaySun)}`;
+}
+
+/**
+ * Render one boarding row for the weekend image.
+ * datetime is arrival_datetime (for arriving section) or departure_datetime (for departing).
+ */
+function weekendBoardingRow(boarding, datetimeField) {
+  const isoStr = boarding[datetimeField];
+  const nightCount = Math.round(
+    Math.abs(new Date(boarding.departure_datetime) - new Date(boarding.arrival_datetime))
+    / (1000 * 60 * 60 * 24)
+  );
+  const nameStr = decodeEntities(boarding.dog_name);
+  const clientStr = lastName(decodeEntities(boarding.client_name));
+  const label = clientStr ? `${nameStr} (${clientStr})` : nameStr;
+  const isPending = boarding.booking_status === 'pending';
+  const labelSuffix = isPending ? ' (?)' : '';
+  const textColor = isPending ? '#6366f1' : COLORS.unchanged; // indigo for pending
+
+  return h('div', {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: WEEKEND_BOARDING_ROW_H,
+    paddingLeft: H_PADDING,
+    paddingRight: H_PADDING,
+    borderBottom: `1px solid #f3f4f6`,
+  },
+    // Dog name + client
+    h('span', {
+      fontFamily: 'Inter',
+      fontWeight: 400,
+      fontSize: 13,
+      color: textColor,
+      flex: 1,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }, label + labelSuffix),
+    // Datetime
+    h('span', {
+      fontFamily: 'Inter',
+      fontWeight: 400,
+      fontSize: 13,
+      color: COLORS.unchanged,
+      width: 110,
+      textAlign: 'right',
+      flexShrink: 0,
+    }, formatWeekendDatetime(isoStr)),
+    // Night count
+    h('span', {
+      fontFamily: 'Inter',
+      fontWeight: 400,
+      fontSize: 12,
+      color: COLORS.dogCount,
+      width: 60,
+      textAlign: 'right',
+      flexShrink: 0,
+    }, `${nightCount}n`),
+  );
+}
+
+/**
+ * Render one section (Arriving / Departing) with a sage-green header and rows.
+ */
+function buildWeekendSection(title, boardings, datetimeField) {
+  const rows = boardings.length > 0
+    ? boardings.map(b => weekendBoardingRow(b, datetimeField))
+    : [h('div', {
+        display: 'flex',
+        alignItems: 'center',
+        height: WEEKEND_BOARDING_ROW_H,
+        paddingLeft: H_PADDING,
+        fontFamily: 'Inter',
+        fontWeight: 400,
+        fontSize: 13,
+        color: COLORS.dogCount,
+        fontStyle: 'italic',
+      }, '(none this weekend)')];
+
+  return h('div', { display: 'flex', flexDirection: 'column', marginBottom: WEEKEND_SECTION_MARGIN },
+    // Section header
+    h('div', {
+      display: 'flex',
+      alignItems: 'center',
+      height: WEEKEND_SECTION_HEADER_H,
+      paddingLeft: H_PADDING,
+      paddingRight: H_PADDING,
+      backgroundColor: COLORS.workerName, // Sage Green
+      borderRadius: 4,
+      marginBottom: 4,
+    },
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 700,
+        fontSize: 14,
+        color: '#ffffff',
+      }, title),
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 400,
+        fontSize: 12,
+        color: '#e5f5d8',
+        marginLeft: 8,
+      }, `${boardings.length} dog${boardings.length !== 1 ? 's' : ''}`),
+    ),
+    // Rows
+    h('div', {
+      display: 'flex',
+      flexDirection: 'column',
+      backgroundColor: COLORS.workerBg,
+      border: `1px solid ${COLORS.workerBorder}`,
+      borderRadius: 4,
+    }, ...rows),
+  );
+}
+
+/**
+ * Compute total image height for the weekend layout.
+ */
+function computeWeekendImageHeight(arriving, departing) {
+  const sectionH = (count) =>
+    WEEKEND_SECTION_HEADER_H + 4 + Math.max(count, 1) * WEEKEND_BOARDING_ROW_H + WEEKEND_SECTION_MARGIN;
+  return HEADER_H + OUTER_PAD * 2 + sectionH(arriving.length) + sectionH(departing.length);
+}
+
+/**
+ * Build the full satori element tree for the weekend roster image.
+ */
+function buildWeekendLayout(arriving, departing, displayFri, displaySun) {
+  const headerDates = formatWeekendHeaderDates(displayFri, displaySun);
+  const availableWidth = IMAGE_WIDTH - OUTER_PAD * 2;
+
+  return h('div', {
+    display: 'flex',
+    flexDirection: 'column',
+    width: IMAGE_WIDTH,
+    backgroundColor: COLORS.bg,
+    fontFamily: 'Inter',
+  },
+    // Header bar
+    h('div', {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      width: IMAGE_WIDTH,
+      height: HEADER_H,
+      backgroundColor: COLORS.headerBg,
+      paddingLeft: OUTER_PAD,
+      paddingRight: OUTER_PAD,
+    },
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 700,
+        fontSize: 18,
+        color: COLORS.headerText,
+        flex: 1,
+      }, 'Weekend Boarding'),
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 400,
+        fontSize: 13,
+        color: '#94a3b8',
+      }, headerDates),
+    ),
+    // Content
+    h('div', {
+      display: 'flex',
+      flexDirection: 'column',
+      width: availableWidth,
+      padding: OUTER_PAD,
+    },
+      buildWeekendSection('Arriving this weekend', arriving, 'arrival_datetime'),
+      buildWeekendSection('Departing this weekend', departing, 'departure_datetime'),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // HTTP handler
 // ---------------------------------------------------------------------------
 
@@ -446,6 +715,35 @@ export default async function handler(req, res) {
   const expectedToken = process.env.VITE_SYNC_PROXY_TOKEN || '';
   if (!expectedToken || providedToken !== expectedToken) {
     return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const imageType = req.query.type || 'daily';
+
+  // --- Weekend roster path ---
+  if (imageType === 'weekend') {
+    console.log('[RosterImage] Generating weekend roster image');
+    try {
+      const supabase = getSupabase();
+      const { start, end, displayFri, displaySun } = getWeekendWindowISO();
+      const { arriving, departing } = await getWeekendBoardings(supabase, start, end);
+
+      const element = buildWeekendLayout(arriving, departing, displayFri, displaySun);
+      const height = computeWeekendImageHeight(arriving, departing);
+      console.log(`[RosterImage/Weekend] ${arriving.length} arriving, ${departing.length} departing, height: ${height}px`);
+
+      const svg = await satori(element, { width: IMAGE_WIDTH, height, fonts: FONTS });
+      const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: IMAGE_WIDTH } });
+      const pngBuffer = resvg.render().asPng();
+
+      console.log(`[RosterImage/Weekend] PNG: ${pngBuffer.length} bytes`);
+      res.setHeader('Content-Type', 'image/png');
+      res.setHeader('Content-Length', pngBuffer.length);
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      return res.status(200).send(pngBuffer);
+    } catch (err) {
+      console.error('[RosterImage/Weekend] ❌ Error:', err.message, err.stack);
+      return res.status(500).json({ error: err.message });
+    }
   }
 
   // --- Input validation: date param ---

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,23 +1,23 @@
-# Dog Boarding App — Session Handoff (v4.3 in progress)
-**Last updated:** March 8, 2026 (end of session)
+# Dog Boarding App — Session Handoff (v4.4 in progress)
+**Last updated:** March 17, 2026 (end of session)
 
 ---
 
 ## Current State
 
-- **v4.2 LIVE** at [qboarding.vercel.app](https://qboarding.vercel.app)
-- **742 tests, 46 files, 0 failures**
-- **Main branch clean** — all PRs merged
-- **PR #51 open** — `fix/goose-boarding-tests` — extraction tests for Goose case, CI green, ready to merge
-- **Integration check LIVE** — runs 3×/day, last run passed ✅ (0 issues, 11 boardings on schedule, all in DB)
+- **v4.3.0 LIVE** at [qboarding.vercel.app](https://qboarding.vercel.app) — tagged, latest release
+- **746 tests, 46 files, 0 failures**
+- **Main branch clean** — all v4.3 PRs merged
+- **PR #69 merged** — integration check daytime + Step 0 removal + ADD filter fix
+- **feat/friday-pm-notify OPEN** — PR not yet created, branch pushed
+- **Integration check LIVE** — runs 3×/day, now reports daytime count alongside boarding count
 
 ---
 
 ## IMMEDIATE NEXT
 
-1. Merge PR #51 (`fix/goose-boarding-tests`) — just needs merge, CI is green
+1. Merge PR for `feat/friday-pm-notify` (v4.4 Friday PM weekend notify) — in progress
 2. Add Anthropic API credits so the Claude name-check step in the integration check activates (console.anthropic.com → Plans & Billing)
-3. Decide on Step 0 sync fix — see integration check known issues below
 
 ---
 


### PR DESCRIPTION
## Summary

Every Friday at 3pm PDT, a WhatsApp image is sent showing dogs arriving and departing over the weekend (Fri–Sun).

- **notify-friday-pm.yml**: GH Actions cron 0 22 * * 5 (10pm UTC = 3pm PDT, Fridays). Calls GET /api/notify?window=friday-pm. Same curl pattern as existing notify workflows.
- **api/notify.js**: Added friday-pm to VALID_WINDOWS. Distinct early-return branch before the weekday logic — no hash gate, no getPictureOfDay, no live refresh. Builds weekend image URL (?type=weekend), sends via sendRosterImage, writes cron_health as notify-friday-pm.
- **api/roster-image.js**: Added type=weekend path. getWeekendWindowISO() computes Fri-now through Monday-noon-UTC window. getWeekendBoardings() queries boardings with arrival OR departure in window. buildWeekendLayout() renders two-section image: Arriving this weekend / Departing this weekend. Each row: dog name, datetime (Fri 3:00 PM), night count. Pending bookings shown in indigo with (?).

No changes to existing daily roster or daytime logic.

## Test plan
- [x] 746 tests pass, 0 failures
- [x] check:requirements 100% coverage (59/59)
- [x] ESLint clean
- [ ] Verify: trigger workflow manually next Friday (or via workflow_dispatch) — confirm WhatsApp image arrives with correct arriving/departing sections
- [ ] Verify: GET /api/roster-image?type=weekend&token=... returns a 200 PNG with two sections