### PR TITLE
feat: v4.5 sync-before-compare — syncRunner.js + integration check Step 0

### DIFF
--- a/.github/workflows/integration-check.yml
+++ b/.github/workflows/integration-check.yml
@@ -1,8 +1,9 @@
 # Integration check — scrapes the AGYD schedule via real browser + Claude vision,
 # compares against DB, sends WhatsApp report.
 #
-# Step 0 (sync) is currently disabled — see SKIP_SYNC note in integration-check.js.
-# Set skip_sync=false on a manual run to attempt sync (will likely fail until fixed).
+# Step 0 runs schedule sync + drains detail queue before the Playwright compare,
+# so bookings made after midnight UTC but before this check don't appear as false
+# positives. Non-fatal — if sync fails, the check continues with current DB state.
 #
 # Runs 3x/day. Also available on-demand via workflow_dispatch.
 #
@@ -11,19 +12,14 @@
 #
 # Required Repository secrets (Settings → Secrets → Actions → Repository secrets):
 #   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+#   EXTERNAL_SITE_USERNAME, EXTERNAL_SITE_PASSWORD  ← Step 0 re-auth on session expiry
 #   ANTHROPIC_API_KEY
 #   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
 #   INTEGRATION_CHECK_RECIPIENTS  ← separate from NOTIFY_RECIPIENTS (Kate only)
-#   APP_URL, VITE_SYNC_PROXY_TOKEN
 name: Integration Check
 
 on:
   workflow_dispatch:
-    inputs:
-      skip_sync:
-        description: 'Skip Step 0 sync (set false to attempt sync — currently broken)'
-        required: false
-        default: 'true'
   schedule:
     # 1:00 AM PDT (08:00 UTC) — shortly after midnight cron finishes
     - cron: '0 8 * * *'
@@ -55,12 +51,10 @@ jobs:
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          EXTERNAL_SITE_USERNAME: ${{ secrets.EXTERNAL_SITE_USERNAME }}
+          EXTERNAL_SITE_PASSWORD: ${{ secrets.EXTERNAL_SITE_PASSWORD }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
           TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}
           INTEGRATION_CHECK_RECIPIENTS: ${{ secrets.INTEGRATION_CHECK_RECIPIENTS }}
-          APP_URL: ${{ secrets.APP_URL }}
-          VITE_SYNC_PROXY_TOKEN: ${{ secrets.VITE_SYNC_PROXY_TOKEN }}
-          # Scheduled runs always skip sync. Manual runs can override via the input.
-          SKIP_SYNC: ${{ github.event.inputs.skip_sync || 'true' }}

--- a/api/cron-detail.js
+++ b/api/cron-detail.js
@@ -7,11 +7,8 @@
  * NOTE: Hobby plan processes 1 queue item per day (Vercel 10s timeout).
  * Use manual "Sync Now" in the UI for immediate processing of multiple items.
  *
- * Picks the oldest pending item from sync_queue, fetches its detail page,
- * and saves the appointment data. On success marks as 'done'; on failure
- * applies retry backoff (up to 3 retries, then 'failed').
- *
- * Also resets any items stuck in 'processing' for more than 10 minutes.
+ * Core logic lives in src/lib/scraper/syncRunner.js — this is a thin Vercel
+ * handler wrapper responsible only for auth gating and health tracking.
  *
  * Runs on Node.js runtime (NOT edge) so process.env is available.
  *
@@ -19,30 +16,18 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { setSession } from '../src/lib/scraper/auth.js';
-import { fetchAppointmentDetails } from '../src/lib/scraper/extraction.js';
-import { mapAndSaveAppointment } from '../src/lib/scraper/mapping.js';
-import { fetchAndStoreBoardingForm } from '../src/lib/scraper/forms.js';
-import { ensureSession, clearSession } from '../src/lib/scraper/sessionCache.js';
-import {
-  dequeueOne,
-  markDone,
-  markFailed,
-  resetStuck,
-  getQueueDepth,
-} from '../src/lib/scraper/syncQueue.js';
+import { runDetailSync } from '../src/lib/scraper/syncRunner.js';
+import { resetStuck } from '../src/lib/scraper/syncQueue.js';
 import { writeCronHealth } from './_cronHealth.js';
 
 export const config = { runtime: 'nodejs' };
 
 function getSupabase() {
   const url = process.env.VITE_SUPABASE_URL;
-  // Prefer service role key (bypasses RLS) for server-side cron operations
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
   if (!url || !key) throw new Error('Supabase env vars not configured');
   return createClient(url, key);
 }
-
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -57,146 +42,33 @@ export default async function handler(req, res) {
   try {
     const supabase = getSupabase();
 
-    // Ensure we have a valid session before dequeuing anything.
-    // Doing this first means we never need to put an item back if auth fails.
-    // ensureSession re-authenticates automatically if the cache is expired/missing.
-    let cookies;
-    try {
-      cookies = await ensureSession(supabase);
-    } catch (sessionErr) {
-      console.error('[CronDetail] ❌ Could not obtain session:', sessionErr.message);
-      await writeCronHealth(supabase, 'detail', 'failure', { action: 'session_failed' }, sessionErr.message.slice(0, 500));
-      return res.status(200).json({ ok: true, action: 'session_failed', error: sessionErr.message });
-    }
-
-    // Inject session into auth module
-    setSession(cookies);
-
-    // Reset any items stuck in 'processing' before picking a new one
+    // Reset stuck items before processing. runDetailSync is called with
+    // runResetStuck: false because we handle it here explicitly (single call,
+    // no loop — no redundancy concern). This matches pre-refactor behavior.
     const resetCount = await resetStuck(supabase);
     if (resetCount > 0) {
       console.log(`[CronDetail] ⚠️ Reset ${resetCount} stuck item(s) to pending`);
     }
 
-    // Dequeue the next pending item
-    const item = await dequeueOne(supabase);
-    if (!item) {
-      console.log('[CronDetail] 📭 Queue empty — nothing to process');
-      await writeCronHealth(supabase, 'detail', 'success', { action: 'idle' }, null);
-      return res.status(200).json({ ok: true, action: 'idle' });
+    const result = await runDetailSync(supabase, { runResetStuck: false });
+
+    if (result.action === 'session_failed') {
+      await writeCronHealth(supabase, 'detail', 'failure', { action: 'session_failed' }, result.error?.slice(0, 500));
+      return res.status(200).json({ ok: true, ...result });
     }
 
-    const itemType = item.type || 'appointment';
-    const depth = await getQueueDepth(supabase);
-    console.log(`[CronDetail] 🐕 Processing 1 of ${depth + 1} queued: ${item.external_id} (type=${itemType})`);
-    console.log(`[CronDetail]    source_url: ${item.source_url}`);
-
-    // ── Form fetch job ────────────────────────────────────────────────────────
-    if (itemType === 'form') {
-      const { boarding_id: boardingId, external_pet_id: externalPetId } = item.meta || {};
-
-      if (!externalPetId) {
-        // Old queue item without pet ID — log and skip gracefully
-        console.log(`[CronDetail] ⏭️ Form job ${item.external_id} has no external_pet_id — skipping (pre-v3 queue item)`);
-        await markDone(supabase, item.id);
-        const remaining = await getQueueDepth(supabase);
-        await writeCronHealth(supabase, 'detail', 'success', { action: 'skipped', reason: 'no_pet_id', externalId: item.external_id, queueDepth: remaining }, null);
-        return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_pet_id', queueDepth: remaining });
-      }
-
-      console.log(`[CronDetail] 📋 Processing form job: boarding_id=${boardingId}, pet_id=${externalPetId}`);
-
-      try {
-        await fetchAndStoreBoardingForm(supabase, boardingId, externalPetId, item.title || '');
-        await markDone(supabase, item.id);
-
-        const remaining = await getQueueDepth(supabase);
-        console.log(`[CronDetail] ✅ Form stored for boarding ${boardingId}`);
-        console.log(`[CronDetail] 📊 Queue depth remaining: ${remaining}`);
-
-        await writeCronHealth(supabase, 'detail', 'success', { action: 'form_stored', externalId: item.external_id, queueDepth: remaining }, null);
-        return res.status(200).json({ ok: true, action: 'form_stored', externalId: item.external_id, queueDepth: remaining });
-      } catch (formErr) {
-        // Check for session expiry
-        if (formErr.message && formErr.message.includes('Session expired')) {
-          console.log('[CronDetail] 🔒 Session rejected during form fetch — clearing cached session');
-          await clearSession(supabase);
-          await supabase
-            .from('sync_queue')
-            .update({ status: 'pending', processing_started_at: null })
-            .eq('id', item.id);
-          await writeCronHealth(supabase, 'detail', 'success', { action: 'session_cleared' }, null);
-          return res.status(200).json({ ok: true, action: 'session_cleared', reason: 'session_expired' });
-        }
-        const msg = formErr.message.slice(0, 200);
-        console.error(`[CronDetail] ❌ Form fetch failed (retry ${(item.retry_count || 0) + 1}/3): ${msg}`);
-        await markFailed(supabase, item.id, msg);
-        const remaining = await getQueueDepth(supabase);
-        await writeCronHealth(supabase, 'detail', 'success', { action: 'form_failed', externalId: item.external_id, queueDepth: remaining }, null);
-        return res.status(200).json({ ok: true, action: 'form_failed', error: msg, queueDepth: remaining });
-      }
+    if (result.action === 'session_cleared') {
+      await writeCronHealth(supabase, 'detail', 'success', { action: 'session_cleared' }, null);
+      return res.status(200).json({ ok: true, ...result });
     }
 
-    // ── Appointment job (default) ─────────────────────────────────────────────
-    // Extract appointmentId and timestamp from source_url
-    const urlMatch = item.source_url.match(/\/schedule\/a\/([^/]+)\/(\d+)/);
-    const [, appointmentId, timestamp] = urlMatch || [null, item.external_id, ''];
+    await writeCronHealth(supabase, 'detail', 'success', {
+      action: result.action,
+      externalId: result.externalId,
+      queueDepth: result.queueDepth,
+    }, null);
 
-    const externalPetId = item.meta?.external_pet_id || null;
-
-    let details;
-    try {
-      details = await fetchAppointmentDetails(appointmentId, timestamp);
-    } catch (err) {
-      // Check for session expiry specifically
-      if (err.message && err.message.includes('Session expired')) {
-        console.log('[CronDetail] 🔒 Session rejected by server — clearing cached session');
-        await clearSession(supabase);
-        // Reset the dequeued item so it retries after re-auth
-        await supabase
-          .from('sync_queue')
-          .update({ status: 'pending', processing_started_at: null })
-          .eq('id', item.id);
-        await writeCronHealth(supabase, 'detail', 'success', { action: 'session_cleared' }, null);
-        return res.status(200).json({ ok: true, action: 'session_cleared', reason: 'session_expired' });
-      }
-      // Other fetch errors — apply retry backoff
-      const msg = err.message.slice(0, 200);
-      console.error(`[CronDetail] ❌ Failed (retry ${(item.retry_count || 0) + 1}/3): ${msg}`);
-      await markFailed(supabase, item.id, msg);
-      const remaining = await getQueueDepth(supabase);
-      await writeCronHealth(supabase, 'detail', 'success', { action: 'failed', externalId: item.external_id, queueDepth: remaining }, null);
-      return res.status(200).json({ ok: true, action: 'failed', error: msg, queueDepth: remaining });
-    }
-
-    // Use schedule-page data as fallback for pet/client name
-    // (same pattern as sync.js to prevent Unknown dog collapse)
-    if (!details.pet_name && item.title) details.pet_name = item.title;
-
-    try {
-      const saveResult = await mapAndSaveAppointment(details, { supabase, externalPetId });
-      await markDone(supabase, item.id);
-
-      const { stats } = saveResult;
-      const action = stats.syncCreated ? 'created'
-        : stats.syncUpdated || stats.dogUpdated || stats.boardingUpdated ? 'updated'
-        : 'unchanged';
-
-      console.log(`[CronDetail] ✅ Saved: ${details.pet_name || details.external_id} — ${action}`);
-
-      const remaining = await getQueueDepth(supabase);
-      console.log(`[CronDetail] 📊 Queue depth remaining: ${remaining}`);
-
-      await writeCronHealth(supabase, 'detail', 'success', { action, externalId: item.external_id, queueDepth: remaining }, null);
-      return res.status(200).json({ ok: true, action, externalId: item.external_id, queueDepth: remaining });
-    } catch (saveErr) {
-      const msg = saveErr.message.slice(0, 200);
-      console.error(`[CronDetail] ❌ Save failed (retry ${(item.retry_count || 0) + 1}/3): ${msg}`);
-      await markFailed(supabase, item.id, msg);
-      const remaining = await getQueueDepth(supabase);
-      await writeCronHealth(supabase, 'detail', 'success', { action: 'save_failed', externalId: item.external_id, queueDepth: remaining }, null);
-      return res.status(200).json({ ok: true, action: 'save_failed', error: msg, queueDepth: remaining });
-    }
+    return res.status(200).json({ ok: true, ...result });
   } catch (err) {
     console.error('[CronDetail] ❌ Unhandled error:', err.message, err.stack);
     try {

--- a/api/cron-schedule.js
+++ b/api/cron-schedule.js
@@ -12,8 +12,8 @@
  * This ensures bookings in the next 2 weeks are seen every night, and bookings
  * 2–8 weeks out appear within 6 nights (one full cursor cycle over weeks 2–7).
  *
- * Appointment HTML parsing uses a regex-based approach (no DOMParser) so this
- * handler works in the Node.js runtime without browser APIs.
+ * Core logic lives in src/lib/scraper/syncRunner.js — this is a thin Vercel
+ * handler wrapper responsible only for auth gating and health tracking.
  *
  * Runs on Node.js runtime (NOT edge) so process.env is available.
  *
@@ -21,183 +21,16 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { setSession } from '../src/lib/scraper/auth.js';
-import { authenticatedFetch } from '../src/lib/scraper/auth.js';
-import { ensureSession, clearSession } from '../src/lib/scraper/sessionCache.js';
-import { enqueue, getQueueDepth } from '../src/lib/scraper/syncQueue.js';
-import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from '../src/lib/scraper/daytimeSchedule.js';
+import { runScheduleSync } from '../src/lib/scraper/syncRunner.js';
 import { writeCronHealth } from './_cronHealth.js';
 
 export const config = { runtime: 'nodejs' };
 
-const BASE_URL = process.env.VITE_EXTERNAL_SITE_URL || 'https://agirlandyourdog.com';
-const CURSOR_WINDOW_WEEKS = 8; // how many weeks the cursor cycles through
-
-// Known non-boarding title patterns (mirrors sync.js pre-filter)
-const NON_BOARDING_RE = [
-  /(d\/c|\bdc\b)/i,
-  /(p\/g|g\/p|\bpg\b)/i,
-  /\badd\b/i,
-  /switch\s+day/i,
-  /back\s+to\s+\d+/i,
-  /initial\s+eval/i,
-  /^busy$/i,
-];
-
 function getSupabase() {
   const url = process.env.VITE_SUPABASE_URL;
-  // Prefer service role key (bypasses RLS) for server-side cron operations
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
   if (!url || !key) throw new Error('Supabase env vars not configured');
   return createClient(url, key);
-}
-
-/**
- * Build the schedule URL for a specific week start date.
- * /schedule/days-7/YYYY/M/D
- */
-function buildWeekUrl(date) {
-  const y = date.getFullYear();
-  const m = date.getMonth() + 1;
-  const d = date.getDate();
-  return `${BASE_URL}/schedule/days-7/${y}/${m}/${d}`;
-}
-
-/**
- * Fetch one schedule page and return its raw HTML.
- * Throws with message 'SESSION_EXPIRED' if the site serves a login page.
- *
- * This avoids importing parseSchedulePage from schedule.js which uses
- * DOMParser — a browser API unavailable in the Node.js runtime.
- */
-async function fetchScheduleHtml(date) {
-  const url = buildWeekUrl(date);
-  const response = await authenticatedFetch(url);
-  if (!response.ok) throw new Error(`Schedule fetch failed: ${response.status}`);
-  const html = await response.text();
-  if (html.includes('login') && html.includes('password')) {
-    throw new Error('SESSION_EXPIRED');
-  }
-  return html;
-}
-
-/**
- * Extract appointment links from schedule page HTML using regex.
- * No DOMParser required — safe for Node.js runtime.
- *
- * Returns objects with: { id, url, timestamp, petName, clientName, time, title }
- */
-function parseScheduleHtml(html) {
-  const results = [];
-  const seen = new Set();
-
-  // Match each <a> block containing a /schedule/a/{id}/{ts} href.
-  // Appointment links contain only <span>/<div> children — no nested <a>.
-  const blockRe = /<a\b([^>]+href="[^"]*\/schedule\/a\/[^"]*"[^>]*)>([\s\S]*?)<\/a>/gi;
-  let m;
-
-  while ((m = blockRe.exec(html)) !== null) {
-    const attrs = m[1];
-    const inner = m[2];
-
-    const hrefMatch = attrs.match(/href="([^"]+)"/);
-    if (!hrefMatch) continue;
-
-    const href = hrefMatch[1];
-    const urlMatch = href.match(/\/schedule\/a\/([^/]+)\/(\d+)/);
-    if (!urlMatch) continue;
-
-    const id = urlMatch[1];
-    if (seen.has(id)) continue;
-    seen.add(id);
-
-    // Extract text content of named child elements
-    const pick = (cls) => {
-      const r = inner.match(new RegExp(`class="[^"]*${cls}[^"]*"[^>]*>([^<]*)<`));
-      return r ? r[1].trim() : '';
-    };
-
-    // Extract pet IDs from data-pet attributes on event-pet-wrapper elements
-    const petIds = [];
-    const petIdRe = /data-pet="([^"]+)"/g;
-    let petMatch;
-    while ((petMatch = petIdRe.exec(inner)) !== null) {
-      petIds.push(petMatch[1]);
-    }
-
-    const fullUrl = href.startsWith('http') ? href : `${BASE_URL}${href}`;
-    results.push({
-      id,
-      url: fullUrl,
-      timestamp: urlMatch[2],
-      petName: pick('event-pet'),
-      clientName: pick('event-client'),
-      time: pick('day-event-time'),
-      title: pick('day-event-title'),
-      petIds,
-    });
-  }
-
-  return results;
-}
-
-/**
- * Read the current cursor date from sync_settings.
- * Returns today if not set.
- */
-async function getCursorDate(supabase) {
-  const { data } = await supabase
-    .from('sync_settings')
-    .select('schedule_cursor_date')
-    .limit(1)
-    .single();
-
-  if (data?.schedule_cursor_date) {
-    const [y, mo, d] = data.schedule_cursor_date.split('-').map(Number);
-    return new Date(y, mo - 1, d); // local midnight
-  }
-  return new Date(); // first run: start at today
-}
-
-/**
- * Advance the cursor by 7 days.
- * Wraps back to today when the cursor would exceed today + CURSOR_WINDOW_WEEKS weeks.
- */
-function advanceCursor(cursor) {
-  const maxDate = new Date();
-  maxDate.setDate(maxDate.getDate() + CURSOR_WINDOW_WEEKS * 7);
-
-  const next = new Date(cursor);
-  next.setDate(next.getDate() + 7);
-
-  return next > maxDate ? new Date() : next;
-}
-
-/**
- * Persist the cursor date in sync_settings.
- */
-async function saveCursorDate(supabase, date) {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  const isoDate = `${y}-${m}-${d}`;
-
-  const { data: existing } = await supabase
-    .from('sync_settings')
-    .select('id')
-    .limit(1)
-    .single();
-
-  if (existing) {
-    await supabase
-      .from('sync_settings')
-      .update({ schedule_cursor_date: isoDate })
-      .eq('id', existing.id);
-  } else {
-    await supabase
-      .from('sync_settings')
-      .insert({ schedule_cursor_date: isoDate });
-  }
 }
 
 export default async function handler(req, res) {
@@ -212,136 +45,28 @@ export default async function handler(req, res) {
 
   try {
     const supabase = getSupabase();
+    const result = await runScheduleSync(supabase);
 
-    // Ensure we have a valid session — re-authenticates if cache is missing/expired.
-    // Throws if credentials are not configured or auth fails (caught below).
-    let cookies;
-    try {
-      cookies = await ensureSession(supabase);
-    } catch (sessionErr) {
-      console.error('[CronSchedule] ❌ Could not obtain session:', sessionErr.message);
-      await writeCronHealth(supabase, 'schedule', 'failure', { action: 'session_failed' }, sessionErr.message.slice(0, 500));
-      return res.status(200).json({ ok: true, action: 'session_failed', error: sessionErr.message });
+    if (result.action === 'session_failed') {
+      await writeCronHealth(supabase, 'schedule', 'failure', { action: 'session_failed' }, result.error?.slice(0, 500));
+      return res.status(200).json({ ok: true, ...result });
     }
 
-    // Inject session into auth module for authenticatedFetch to use
-    setSession(cookies);
-
-    const cursorDate = await getCursorDate(supabase);
-    const today = new Date();
-
-    console.log(`[CronSchedule] 📅 Starting scan — cursor: ${cursorDate.toDateString()}, mode: micro`);
-    console.log(`[CronSchedule] 🔑 Session: cached`);
-
-    const stats = { pagesScanned: 0, found: 0, skipped: 0, queued: 0, daytimeUpserted: 0, daytimeErrors: 0 };
-
-    // Page 1: current week — always fetched
-    const datesToFetch = [today];
-    // Page 2: next week — always fetched (eliminates 1-week discovery blind spot)
-    const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
-    datesToFetch.push(nextWeek);
-    // Page 3: cursor week (rotating, weeks 2–8) — skip if it overlaps page 1 or 2
-    const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-    const sameAsToday    = Math.abs(cursorDate - today)    < ONE_WEEK_MS;
-    const sameAsNextWeek = Math.abs(cursorDate - nextWeek) < ONE_WEEK_MS;
-    if (!sameAsToday && !sameAsNextWeek) datesToFetch.push(cursorDate);
-
-    const seenIds = new Set();
-    const appointments = [];
-    // Accumulates all daytime/boarding events across both fetched pages.
-    // upsertDaytimeAppointments deduplicates before the DB write.
-    const allDaytimeAppts = [];
-
-    for (const date of datesToFetch) {
-      let html;
-      try {
-        html = await fetchScheduleHtml(date);
-      } catch (err) {
-        if (err.message === 'SESSION_EXPIRED') {
-          console.log('[CronSchedule] 🔒 Session rejected by server — clearing cached session');
-          await clearSession(supabase);
-          await writeCronHealth(supabase, 'schedule', 'success', { action: 'session_cleared', reason: 'session_expired' }, null);
-          return res.status(200).json({ ok: true, action: 'session_cleared', reason: 'session_expired' });
-        }
-        throw err;
-      }
-
-      const parsed = parseScheduleHtml(html);
-      stats.pagesScanned++;
-      console.log(`[CronSchedule] 📋 Found ${parsed.length} appointments on ${date.toDateString()} page`);
-
-      for (const appt of parsed) {
-        if (seenIds.has(appt.id)) continue;
-        seenIds.add(appt.id);
-        appointments.push(appt);
-      }
-
-      // Parse ALL events (DC, PG, Boarding) for daytime activity ingestion.
-      // Runs against the same HTML — no extra fetches.
-      const daytimeAppts = parseDaytimeSchedulePage(html);
-      console.log(`[CronSchedule] 🏃 Parsed ${daytimeAppts.length} daytime events on ${date.toDateString()} page`);
-      allDaytimeAppts.push(...daytimeAppts);
+    if (result.action === 'session_cleared') {
+      await writeCronHealth(supabase, 'schedule', 'success', { action: 'session_cleared', reason: result.reason }, null);
+      return res.status(200).json({ ok: true, ...result });
     }
 
-    stats.found = appointments.length;
+    await writeCronHealth(supabase, 'schedule', 'success', {
+      pagesScanned: result.pagesScanned,
+      found: result.found,
+      skipped: result.skipped,
+      queued: result.queued,
+      cursorAdvancedTo: result.cursorAdvancedTo,
+      queueDepth: result.queueDepth,
+    }, null);
 
-    // Filter and enqueue boarding candidates
-    for (const appt of appointments) {
-      const titleLower = (appt.title || '').toLowerCase().trim();
-      const isNonBoarding = NON_BOARDING_RE.some(re => re.test(titleLower));
-
-      if (isNonBoarding) {
-        stats.skipped++;
-        continue;
-      }
-
-      try {
-        await enqueue(supabase, {
-          external_id: appt.id,
-          source_url: appt.url,
-          title: appt.title || appt.petName || '',
-          meta: appt.petIds?.[0] ? { external_pet_id: appt.petIds[0] } : {},
-        });
-        stats.queued++;
-      } catch (err) {
-        // Log but don't fail the whole run for one enqueue error
-        console.error(`[CronSchedule] ⚠️ Failed to enqueue ${appt.id}:`, err.message);
-      }
-    }
-
-    console.log(`[CronSchedule] 🐕 ${stats.found} found, ${stats.skipped} skipped (non-boarding), ${stats.queued} queued`);
-
-    // Upsert all daytime appointments collected from every fetched page.
-    // This runs after the boarding queue loop so queue errors don't block it.
-    const daytimeResult = await upsertDaytimeAppointments(supabase, allDaytimeAppts);
-    stats.daytimeUpserted = daytimeResult.upserted;
-    stats.daytimeErrors = daytimeResult.errors;
-    console.log(`[CronSchedule] 📊 Daytime upserted: ${daytimeResult.upserted}, errors: ${daytimeResult.errors}`);
-
-    // Advance cursor
-    const nextCursor = advanceCursor(cursorDate);
-    await saveCursorDate(supabase, nextCursor);
-    const wrapped = nextCursor <= today;
-    if (wrapped) {
-      console.log('[CronSchedule] 🔄 Cursor wrapped back to today');
-    } else {
-      console.log(`[CronSchedule] ➡️ Cursor advanced to ${nextCursor.toDateString()}`);
-    }
-
-    const depth = await getQueueDepth(supabase);
-    console.log(`[CronSchedule] 📊 Queue depth after scan: ${depth} pending`);
-
-    const healthResult = {
-      pagesScanned: stats.pagesScanned,
-      found: stats.found,
-      skipped: stats.skipped,
-      queued: stats.queued,
-      cursorAdvancedTo: nextCursor.toISOString().slice(0, 10),
-      queueDepth: depth,
-    };
-    await writeCronHealth(supabase, 'schedule', 'success', healthResult, null);
-
-    return res.status(200).json({ ok: true, ...healthResult });
+    return res.status(200).json({ ok: true, ...result });
   } catch (err) {
     console.error('[CronSchedule] ❌ Unhandled error:', err.message, err.stack);
     try {

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,4 +1,4 @@
-# Dog Boarding App — Session Handoff (v4.4.2 live, v4.5 planned)
+# Dog Boarding App — Session Handoff (v4.4.3 pending, v5.0 next)
 **Last updated:** March 20, 2026
 
 ---
@@ -6,46 +6,31 @@
 ## Current State
 
 - **v4.4.2 LIVE** at [qboarding.vercel.app](https://qboarding.vercel.app) — tagged, latest release
-- **758 tests, 46 files, 0 failures**
-- **Main branch clean** — latest merged: #85
-- **PR #86 open** (`fix/stable-sort-hash`) — fix for false UPDATED! resends; more changes coming before merge
-- **Integration check LIVE** — runs 3×/day; known false positive pattern: new bookings made after midnight cron but before the 8am check will appear as "Missing from DB" (confirmed with Corky Ortiz on 3/20 — booking added at ~9:17pm PDT, after midnight UTC sync ran)
-- **v4 complete** — all tickets done; v4.5 planned (integration check sync-before-compare)
+- **775 tests, 47 files, 0 failures**
+- **PR #86 merged** — stable alpha sort fix (v4.4.3 tag pending PR merge of v4.5 branch)
+- **PR open** (`feat/v4.5-sync-runner`) — v4.5 implementation, issue #87
+- **Integration check LIVE** — v4.5 will eliminate the known false positive for post-midnight bookings
 - **`cron_health_log` verified** — table live, first row written (manual trigger March 19)
 
 ---
 
 ## IMMEDIATE NEXT (next session)
 
-1. **Merge PR #86** (`fix/stable-sort-hash`) — after adding any remaining changes; tag v4.4.3
-2. **Plan + build v4.5** — integration check sync-before-compare (see TODO below)
-3. **Start v5.0** — see `docs/SPRINT_PLAN.md`. First ticket: Gmail monitoring agent (ticket #1)
+1. **Merge v4.5 PR** (`feat/v4.5-sync-runner`) — add `EXTERNAL_SITE_USERNAME` + `EXTERNAL_SITE_PASSWORD` as GH repo secrets first (see below), then merge + tag v4.4.3
+2. **Start v5.0** — see `docs/SPRINT_PLAN.md`. First ticket: Gmail monitoring agent
 
 ---
 
-## TODO: v4.5 — Integration Check Sync-Before-Compare
+## ⚠️ ACTION REQUIRED BEFORE MERGING v4.5
 
-**Problem:** The integration check runs at 1am, 9am, 5pm PDT. The midnight cron syncs at 00:00–00:15 UTC. A booking made after midnight UTC but before the 1am check appears as "Missing from DB" — it's a real booking, not a bug. The integration check has no way to sync before comparing.
+Add two new GH repo secrets (Settings → Secrets → Actions → Repository secrets):
 
-**Prior attempt (removed):** `api/run-sync.js` used `DOMParser` (browser-only) and hit Vercel's 10s HTTP timeout. Removed entirely; `SKIP_SYNC` env var and workflow comment are now dead code.
+| Secret | Value | Purpose |
+|---|---|---|
+| `EXTERNAL_SITE_USERNAME` | AGYD login email | Step 0 re-auth when session is expired |
+| `EXTERNAL_SITE_PASSWORD` | AGYD login password | Step 0 re-auth when session is expired |
 
-**Why not call Vercel cron endpoints via HTTP (Option A):** Vercel Hobby plan caps external HTTP calls at 10s. `cron-schedule` scrapes 3 pages (~5–8s) — at the limit. `cron-detail` would timeout for any non-trivial queue. Fragile.
-
-**Chosen approach (Option B):** Extract the core sync logic from the Vercel handler wrappers into importable Node.js functions. The integration check calls them directly — no Vercel HTTP layer, no timeout risk, no new secrets.
-
-**What needs to happen:**
-- `api/cron-schedule.js` — extract inner logic (fetch schedule pages, parse, enqueue) into `src/lib/scraper/syncRunner.js` (or similar). The Vercel handler becomes a thin wrapper.
-- `api/cron-detail.js` — same: extract dequeue+fetch+map loop into the shared module.
-- `scripts/integration-check.js` — import and call the sync runner functions as Step 0, before Playwright scrape. Session is already loaded in Step 1; pass it through.
-- Remove dead `SKIP_SYNC` env var from workflow + workflow comment.
-- Update `docs/job_docs/integration-check.md` with new Step 0 description.
-
-**Key constraints:**
-- `cron-schedule.js` is already Node.js safe (regex-based, no DOMParser) ✓
-- `cron-detail.js` is already Node.js safe ✓
-- Do NOT import from `src/lib/scraper/` for the Playwright/Claude signal path — signal isolation must be preserved. The sync runner is a separate step that runs BEFORE the independent check, not part of it.
-- `SKIP_SYNC` env var + workflow input should be cleaned up (dead code since Step 0 was removed)
-- `APP_URL` + `VITE_SYNC_PROXY_TOKEN` secrets are no longer needed in the integration check workflow once this is done (they were for the old HTTP approach)
+These are already Vercel env vars — copy the values from there. Without them, Step 0 still runs but can't re-authenticate if the session is stale (degrades gracefully, does not break anything).
 
 ---
 
@@ -118,13 +103,14 @@
 
 ### Integration check flow
 ```
-GitHub Actions (3×/day + on-demand, SKIP_SYNC=true)
-  → Load session cookies from sync_settings (Supabase)
-  → Playwright: render /schedule, screenshot + DOM link extraction
-  → Claude vision: screenshot → dog names[] (silently skipped — no API credits)
-  → Supabase: boardings JOIN dogs (past 7d → today+7d); daytime_appointments (today)
-  → compareResults: missing IDs, Unknown names, name mismatches (boarding); missing daytime events
-  → Twilio WhatsApp → INTEGRATION_CHECK_RECIPIENTS
+GitHub Actions (3×/day + on-demand)
+  → Step 0: runScheduleSync + drain runDetailSync (max 20 iters) — non-fatal
+  → Step 1: Load session cookies from sync_settings (Supabase)
+  → Step 2: Playwright: render /schedule, screenshot + DOM link extraction
+  → Step 3: Claude vision: screenshot → dog names[] (silently skipped — no API credits)
+  → Step 4: Supabase: boardings JOIN dogs (past 7d → today+7d); daytime_appointments (today)
+  → Step 5: compareResults: missing IDs, Unknown names, name mismatches (boarding); missing daytime events
+  → Step 6: Twilio WhatsApp → INTEGRATION_CHECK_RECIPIENTS
 ```
 
 ### Notify flow
@@ -140,8 +126,8 @@ GitHub Actions (4 workflows: M-F 4am/7am/8:30am + Fri 3pm PDT)
 | File | Purpose |
 |---|---|
 | `scripts/integration-check.js` | Integration check script (GH Actions) |
-| `api/run-sync.js` | On-demand sync endpoint (Step 0 — currently broken) |
-| `.github/workflows/integration-check.yml` | 3×/day + on-demand, SKIP_SYNC env var |
+| `src/lib/scraper/syncRunner.js` | Extracted sync logic — `runScheduleSync`, `runDetailSync` (v4.5) |
+| `.github/workflows/integration-check.yml` | 3×/day + on-demand |
 | `docs/job_docs/integration-check.md` | Full reference doc for the integration check |
 | `src/lib/pictureOfDay.js` | getPictureOfDay, computeWorkerDiff, hashPicture |
 | `api/roster-image.js` | Token-gated PNG endpoint |
@@ -161,8 +147,10 @@ GitHub Actions (4 workflows: M-F 4am/7am/8:30am + Fri 3pm PDT)
 | `TWILIO_FROM_NUMBER` | ✅ Set |
 | `NOTIFY_RECIPIENTS` | ✅ Set (1 number — second pending Kate) |
 | `INTEGRATION_CHECK_RECIPIENTS` | ✅ Set (Kate's number only) |
-| `APP_URL` | ✅ Set |
-| `VITE_SYNC_PROXY_TOKEN` | ✅ Set |
+| `EXTERNAL_SITE_USERNAME` | ⚠️ Needs to be added (v4.5 Step 0 re-auth) |
+| `EXTERNAL_SITE_PASSWORD` | ⚠️ Needs to be added (v4.5 Step 0 re-auth) |
+| `APP_URL` | ✅ Set (no longer used in integration-check workflow) |
+| `VITE_SYNC_PROXY_TOKEN` | ✅ Set (no longer used in integration-check workflow) |
 
 ### Workers
 | Name | External UID |

--- a/docs/job_docs/integration-check.md
+++ b/docs/job_docs/integration-check.md
@@ -1,7 +1,7 @@
 # Integration Check Job
 
-**Status:** Live — boarding + daytime checks, Step 0 removed, always exits 0
-**Last reviewed:** March 19, 2026
+**Status:** Live — Step 0 sync-before-compare (v4.5), boarding + daytime checks, always exits 0
+**Last reviewed:** March 20, 2026
 
 ---
 
@@ -27,6 +27,18 @@ If either signal sees something the DB doesn't have → WhatsApp to Kate.
 ---
 
 ## How It Works (Step by Step)
+
+### Step 0 — Sync-before-compare *(v4.5)*
+Runs the schedule sync and drains the detail queue **before** the Playwright compare. This eliminates the known false positive where a booking made after midnight UTC (after the midnight cron ran) but before the 1am check appears as "Missing from DB."
+
+- Calls `runScheduleSync(supabase)` from `src/lib/scraper/syncRunner.js` — scans schedule pages, enqueues new items, upserts daytime events
+- Calls `runDetailSync(supabase)` in a loop (max 20 iterations) until `action === 'idle'`, processing any newly queued (or previously queued) detail items
+- `resetStuck` is called once before the loop, not on every iteration (avoids 20 redundant DB queries)
+- **Non-fatal** — if Step 0 throws for any reason (session expired and no credentials configured, network error), the error is logged and the check continues to Step 1 with whatever is currently in the DB
+- Does NOT call `writeCronHealth` — health tracking is the Vercel cron handlers' responsibility. Step 0 is a "best effort" sync, not a scheduled cron run.
+- Signal isolation is preserved: Steps 2–5 (Playwright, Claude, DB compare) are unchanged and import nothing from `src/lib/scraper/`. Step 0 runs before the independent check begins.
+
+**Session re-auth in Step 0:** `ensureSession` can re-authenticate if the session is expired, provided `EXTERNAL_SITE_USERNAME` and `EXTERNAL_SITE_PASSWORD` are set as GH repo secrets. If they are, a stale session will be refreshed and the fresh session is available to Step 1's `loadSession` (making Playwright work too). If they're not set, re-auth silently fails and Step 0 is skipped.
 
 ### Step 1 — Load session cookies
 Reads `session_cookies` from `sync_settings` in Supabase — the same auth token the midnight cron uses. If missing or expired, sends WhatsApp and exits. The session is refreshed by `cron-auth.js` which runs at midnight.
@@ -124,15 +136,17 @@ All must be **Repository secrets** in GitHub (Settings → Secrets → Actions �
 |---|---|---|
 | `VITE_SUPABASE_URL` | Supabase project URL (public) | Supabase project settings |
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role key — bypasses RLS | Supabase project settings → API → Secret keys |
+| `EXTERNAL_SITE_USERNAME` | AGYD login email — Step 0 re-auth | Copy from Vercel env vars |
+| `EXTERNAL_SITE_PASSWORD` | AGYD login password — Step 0 re-auth | Copy from Vercel env vars |
 | `ANTHROPIC_API_KEY` | Claude API key | console.anthropic.com → API Keys |
 | `TWILIO_ACCOUNT_SID` | Twilio account | Copy from Vercel env vars |
 | `TWILIO_AUTH_TOKEN` | Twilio auth token | Copy from Vercel env vars |
 | `TWILIO_FROM_NUMBER` | Twilio sandbox number | Copy from Vercel env vars |
 | `INTEGRATION_CHECK_RECIPIENTS` | Kate's phone number only (E.164) | Manually set — NOT from Vercel |
 
-Note: `TWILIO_*` and `SUPABASE_SERVICE_ROLE_KEY` are also Vercel env vars. They must be separately added as GH repo secrets — Vercel and GitHub Actions do not share env vars.
+Note: `TWILIO_*`, `SUPABASE_SERVICE_ROLE_KEY`, `EXTERNAL_SITE_USERNAME`, and `EXTERNAL_SITE_PASSWORD` are also Vercel env vars. They must be separately added as GH repo secrets — Vercel and GitHub Actions do not share env vars.
 
-`APP_URL` and `VITE_SYNC_PROXY_TOKEN` are no longer required (Step 0 removed).
+`APP_URL` and `VITE_SYNC_PROXY_TOKEN` were removed in v4.5 (Step 0 no longer uses an HTTP endpoint).
 
 ---
 

--- a/docs/specs/v4.5-syncrunner-design-review.md
+++ b/docs/specs/v4.5-syncrunner-design-review.md
@@ -1,0 +1,143 @@
+# v4.5 syncRunner.js — Senior Staff Engineer Design Review
+
+_Authored: March 20, 2026 — pre-implementation review for PR to close issue #87_
+
+---
+
+## 1. Decision Log Logic — Critical Branching Points
+
+### `runScheduleSync(supabase)`
+
+| Branching Point | What to Log |
+|---|---|
+| `ensureSession` outcome | `[SyncRunner:Schedule] Session obtained` or `session_failed: {err.message}` |
+| Each schedule page fetch | `[SyncRunner:Schedule] Fetching {date} — url: {url}` |
+| SESSION_EXPIRED detection | `[SyncRunner:Schedule] SESSION_EXPIRED detected on {date} — clearing session` |
+| Per-appointment filter decision | `[SyncRunner:Schedule] SKIP {id} — matched NON_BOARDING_RE` vs `ENQUEUE {id} title="{title}"` |
+| Enqueue failure (non-fatal) | `[SyncRunner:Schedule] ⚠️ Enqueue failed for {id}: {err.message}` — must not swallow |
+| Daytime parse result | `[SyncRunner:Schedule] Daytime parsed: {n} events from {date}` |
+| Cursor advance | `[SyncRunner:Schedule] Cursor {oldDate} → {newDate}` or `wrapped to today` |
+
+### `runDetailSync(supabase)`
+
+| Branching Point | What to Log |
+|---|---|
+| Queue empty | `[SyncRunner:Detail] Queue empty — idle` |
+| Item type dispatch | `[SyncRunner:Detail] Processing {id} type={itemType} (retry {n}/3)` |
+| SESSION_EXPIRED during fetch | `[SyncRunner:Detail] SESSION_EXPIRED on {id} — clearing + re-queuing` |
+| Form job: missing pet ID | `[SyncRunner:Detail] SKIP form {id} — no external_pet_id (pre-v3 item)` |
+| Save outcome | `[SyncRunner:Detail] {id} → {created|updated|unchanged} dog={petName}` |
+| markFailed | `[SyncRunner:Detail] FAIL {id} retry={n}/3: {msg}` |
+
+### Integration Check Step 0 (caller context)
+
+| Point | What to Log |
+|---|---|
+| Step 0 start | `[IntegCheck] Step 0: running sync-before-compare` |
+| Schedule sync result | `[IntegCheck] Step 0 schedule: {pagesScanned} pages, {queued} queued` |
+| Each detail iteration | `[IntegCheck] Step 0 detail [{i}/20]: action={action} queueDepth={n}` |
+| Step 0 complete | `[IntegCheck] Step 0 done: {n} detail iterations, queue drained` |
+| Step 0 error (non-fatal) | `[IntegCheck] Step 0 error (continuing): {err.message}` |
+| Cap hit without draining | `[IntegCheck] ⚠️ Step 0 detail: hit 20-iteration cap without reaching idle` |
+
+---
+
+## 2. Pattern Alignment
+
+### Use These Patterns
+
+- **Dependency Injection** — `supabase` is passed in. `syncRunner.js` creates nothing. The caller owns the client and controls the key scope.
+- **Result Objects** — both runners return plain objects `{ action, ... }`. Callers decide what to do with them (Vercel handlers write health; integration check just logs). No side effects leaking out.
+- **Non-fatal Step 0** — integration check wraps Step 0 in try/catch; a sync failure never aborts the Playwright check.
+
+### Anti-Patterns to Explicitly Avoid
+
+- **Hidden State via `setSession`** — `auth.js` has module-level session state. `runScheduleSync` calls `setSession(cookies)` as the cron handler does today. Safe in Node.js (single process), but **must be documented in the JSDoc** so the next reader isn't confused by the side effect.
+- **Health writes inside the runner** — `writeCronHealth` stays in Vercel handlers ONLY. If the runner wrote health, a call from the integration check at 8am would overwrite the midnight cron's health record — silent data loss.
+- **Intentional duplication of `NON_BOARDING_RE`** — this pattern lives in `syncRunner.js` (cron path imports it) AND stays independently defined in `integration-check.js` (signal isolation). That is the one intentional duplication. Document it clearly; do not "fix" it by importing from syncRunner into integration-check.
+
+---
+
+## 3. Implementation Strategy
+
+1. **Write `syncRunner.js` first** — move private helpers (`buildWeekUrl`, `fetchScheduleHtml`, `parseScheduleHtml`, `getCursorDate`, `advanceCursor`, `saveCursorDate`, `NON_BOARDING_RE`) out of `cron-schedule.js` into the runner. Implement `runScheduleSync(supabase)` and `runDetailSync(supabase)` as the two exports. No health writes inside.
+
+2. **Slim the Vercel handlers** — `cron-schedule.js` becomes: auth gate → `getSupabase()` → `runScheduleSync(supabase)` → `writeCronHealth` → return JSON. Same for `cron-detail.js`. Verify `cron-detail-2.js` re-export still works (no changes needed).
+
+3. **Add Step 0 to `integration-check.js`** — before Step 1 (session load), add a try/catch block that imports `{ runScheduleSync, runDetailSync }`, calls schedule sync, then loops `runDetailSync` until `action === 'idle'` or 20 iterations. Log every iteration. Non-fatal on any throw.
+
+4. **Clean up the workflow** — remove `SKIP_SYNC` env var and `APP_URL`/`VITE_SYNC_PROXY_TOKEN` from `integration-check.yml`. GH secrets themselves are not deleted.
+
+5. **Tests + docs** — unit tests for pure functions (`buildWeekUrl`, `advanceCursor`); test for the Step 0 loop behavior (mock `runDetailSync` returning `idle` after 2 iterations); update `integration-check.md` with Step 0; update `SESSION_HANDOFF.md`. Remove stale `api/run-sync.js` reference from SESSION_HANDOFF architecture table.
+
+---
+
+## 4. Code Written Once, Called From Everywhere
+
+After this change, every consumer of the sync logic calls the runner. If a bug is found in schedule parsing, fix it once in `syncRunner.js` — both the Vercel cron and the integration check are fixed. The cron handlers and integration check are consumers, not owners, of the logic.
+
+---
+
+## 5. Security Surface Area
+
+### Supabase RLS
+
+- `sync_settings` — contains raw session cookies. Read via `ensureSession`. **Service role key only.** `syncRunner.js` accepts `supabase` as a param and never instantiates its own client — the caller controls the key scope. This must not change.
+- `sync_queue`, `boardings`, `dogs`, `daytime_appointments` — write via `enqueue`, `mapAndSaveAppointment`. All service role. No new surface.
+- `cron_health`, `cron_health_log` — NOT written by the runner. Stays in Vercel handlers.
+
+### Environment Variables
+
+| Var | Secret? | Who reads it |
+|---|---|---|
+| `VITE_SUPABASE_URL` | No (public URL) | Caller's `getSupabase()` |
+| `SUPABASE_SERVICE_ROLE_KEY` | **Yes** | Caller's `getSupabase()` |
+| `EXTERNAL_SITE_USERNAME` | **Yes** | `auth.js` → `ensureSession` (re-auth path only) |
+| `EXTERNAL_SITE_PASSWORD` | **Yes** | `auth.js` → `ensureSession` (re-auth path only) |
+| `VITE_EXTERNAL_SITE_URL` | No | `syncRunner.js` BASE_URL (defaults to hardcoded URL) |
+
+### Data Validation
+
+No user input flows through this module. Data pipeline is AGYD HTML → existing regex parsers → Supabase. No new injection surface introduced.
+
+---
+
+## 6. Gaps Identified (Not in Original Plan)
+
+### GAP 1 — CRITICAL: `EXTERNAL_SITE_USERNAME` / `EXTERNAL_SITE_PASSWORD` not in GH Actions
+
+`ensureSession` has two paths: (a) cache hit → return session (no credentials needed), (b) cache miss/expired → re-authenticate using `EXTERNAL_SITE_USERNAME` + `EXTERNAL_SITE_PASSWORD`.
+
+The GH Actions workflow for integration check does NOT have these credentials. In path (a) — normal operation — this is fine. In path (b) — stale session — `ensureSession` will throw, Step 0 catches it non-fatally, and integration check continues with whatever is in the DB.
+
+**The opportunity:** if we add `EXTERNAL_SITE_USERNAME` and `EXTERNAL_SITE_PASSWORD` as GH secrets and pass them to the workflow, Step 0 can fully re-authenticate on session expiry. The fresh session gets written to `sync_settings`. Step 1 (`loadSession`) then picks it up. Playwright gets valid cookies. The entire check becomes self-healing even when midnight cron-auth had problems.
+
+This is a meaningful enhancement. Decision: add to this PR or defer to v4.6?
+
+### GAP 2: Cursor Advance Side Effect
+
+`runScheduleSync` advances `schedule_cursor_date` in `sync_settings` every time it's called. With the integration check calling it 3×/day, the cursor advances 3 extra times per day beyond the midnight cron. The cursor cycles over 8 weeks so this is functionally harmless, but the cursor will no longer cleanly represent "how far the midnight cron has advanced." Acceptable tradeoff — worth documenting.
+
+### GAP 3: `resetStuck` Called in Every Detail Loop Iteration
+
+`runDetailSync` calls `resetStuck` at the start of each call. When looped 20 times in Step 0, this calls `resetStuck` 20 times. It's idempotent and cheap (one DB query), but slightly wasteful. Optimization: the integration check loop could pass a flag to skip `resetStuck` after the first iteration. Low priority — not a blocker.
+
+### GAP 4: `api/run-sync.js` Reference in SESSION_HANDOFF
+
+The SESSION_HANDOFF architecture table still references `api/run-sync.js` as "currently broken." After v4.5, that table entry should be removed — Step 0 is now `syncRunner.js`, not an HTTP endpoint.
+
+### GAP 5: Enqueue Idempotency Assumption
+
+The plan assumes `enqueue` is idempotent (safe to enqueue an ID already in the queue or already done). This should be verified before implementation. If `enqueue` throws on duplicate external_id, Step 0's schedule scan would error noisily for every appointment that was already processed by the midnight cron.
+
+---
+
+## Decision Log
+
+| Decision | Rationale |
+|---|---|
+| Runners don't call `writeCronHealth` | Health writes from integration check would overwrite midnight cron's record |
+| Step 0 is non-fatal | Sync failure should not abort the independent Playwright/DB compare |
+| `NON_BOARDING_RE` intentionally duplicated in integration-check.js | Signal isolation — integration check must not share parsing code with the sync pipeline |
+| Loop `runDetailSync` max 20 iterations | Prevents runaway loop while handling edge case of multiple queued items |
+| Step 0 runs before Step 1 (`loadSession`) | If Step 0 refreshes the session, Step 1 reads the fresh cookies for Playwright |

--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -2,10 +2,10 @@
 /**
  * Integration check — independent verification of sync health.
  *
- * WHY this is decoupled from src/lib/scraper/:
+ * WHY this is decoupled from src/lib/scraper/ for Steps 2–5:
  *   The sync pipeline parses raw HTML with regexes. If that parser has a bug,
  *   using the same parser here would confirm its wrong output and call it a
- *   pass. This script uses two independent signal paths instead:
+ *   pass. Steps 2–5 use two independent signal paths instead:
  *
  *   1. Playwright renders the schedule page in a real browser, then
  *      document.querySelectorAll reads the live DOM — no regex, no raw HTML.
@@ -15,7 +15,15 @@
  *   Both signals are compared against the DB to catch bugs the sync pipeline
  *   cannot catch about itself.
  *
+ * WHY NON_BOARDING_PATTERNS is defined here instead of imported from syncRunner:
+ *   Signal isolation. If syncRunner's parser had a bug that misclassified a
+ *   non-boarding event as boarding, importing its filter would propagate the
+ *   same bug into the check. This copy is intentionally independent.
+ *
  * Flow:
+ *   0. Sync-before-compare: run schedule sync + drain detail queue so any
+ *      bookings added since the midnight cron are in the DB before we compare.
+ *      Non-fatal — if sync fails, the check continues with the current DB state.
  *   1. Load session cookies from Supabase sync_settings (same cache the crons use)
  *   2. Playwright: render /schedule, take screenshot + extract appointment IDs
  *      from live DOM links (boarding + daytime)
@@ -28,6 +36,7 @@
  *
  * Required env vars (GitHub Actions Repository secrets):
  *   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ *   EXTERNAL_SITE_USERNAME, EXTERNAL_SITE_PASSWORD  (for Step 0 re-auth on session expiry)
  *   ANTHROPIC_API_KEY
  *   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
  *   INTEGRATION_CHECK_RECIPIENTS  (separate from NOTIFY_RECIPIENTS)
@@ -37,6 +46,8 @@ import { chromium } from 'playwright';
 import Anthropic from '@anthropic-ai/sdk';
 import { createClient } from '@supabase/supabase-js';
 import twilio from 'twilio';
+import { runScheduleSync, runDetailSync } from '../src/lib/scraper/syncRunner.js';
+import { resetStuck } from '../src/lib/scraper/syncQueue.js';
 
 const BASE_URL = 'https://agirlandyourdog.com';
 const WINDOW_DAYS = 7;
@@ -521,6 +532,54 @@ async function main() {
     console.error('[IntegCheck]', msg);
     await sendWhatsApp(twilioClient, msg);
     process.exit(1);
+  }
+
+  // Step 0: Sync-before-compare
+  // Run schedule sync + drain detail queue so any bookings made since the midnight
+  // cron are in the DB before we compare. Non-fatal — if sync fails for any reason
+  // (session expired, network error, missing credentials), we log and continue.
+  // The check will run against whatever is currently in the DB.
+  //
+  // runDetailSync is called with runResetStuck:false after the first iteration —
+  // resetStuck is called once manually to avoid redundant DB queries in the loop.
+  console.log('[IntegCheck] Step 0: running sync-before-compare');
+  try {
+    const scheduleResult = await runScheduleSync(supabase);
+    console.log(
+      '[IntegCheck] Step 0 schedule: action=%s pagesScanned=%d queued=%d queueDepth=%d',
+      scheduleResult.action,
+      scheduleResult.pagesScanned,
+      scheduleResult.queued,
+      scheduleResult.queueDepth,
+    );
+
+    if (scheduleResult.action === 'ok' || scheduleResult.action === 'session_cleared') {
+      // Drain the detail queue. Reset stuck items once before the loop, then skip
+      // on subsequent iterations to avoid 20 redundant DB queries (Gap 3 fix).
+      const MAX_DETAIL_ITERATIONS = 20;
+      await resetStuck(supabase);
+      let drained = 0;
+      for (let i = 0; i < MAX_DETAIL_ITERATIONS; i++) {
+        const detailResult = await runDetailSync(supabase, { runResetStuck: false });
+        console.log(
+          '[IntegCheck] Step 0 detail [%d/%d]: action=%s queueDepth=%d',
+          i + 1,
+          MAX_DETAIL_ITERATIONS,
+          detailResult.action,
+          detailResult.queueDepth ?? 0,
+        );
+        drained++;
+        if (detailResult.action === 'idle' || detailResult.action === 'session_cleared' || detailResult.action === 'session_failed') {
+          break;
+        }
+        if (i === MAX_DETAIL_ITERATIONS - 1) {
+          console.warn('[IntegCheck] ⚠️ Step 0 detail: hit %d-iteration cap without reaching idle — queue may still have items', MAX_DETAIL_ITERATIONS);
+        }
+      }
+      console.log('[IntegCheck] Step 0 done: %d detail iteration(s)', drained);
+    }
+  } catch (step0Err) {
+    console.error('[IntegCheck] Step 0 error (continuing to check): %s', step0Err.message);
   }
 
   // Step 1: Session

--- a/src/__tests__/scraper/syncRunner.test.js
+++ b/src/__tests__/scraper/syncRunner.test.js
@@ -1,0 +1,311 @@
+/**
+ * syncRunner tests — pure helpers and key runner branches.
+ *
+ * Pure functions (buildWeekUrl, advanceCursor, parseScheduleHtml) are tested
+ * directly. Runner functions (runScheduleSync, runDetailSync) are tested via
+ * mocked dependencies to cover critical branches without network calls.
+ *
+ * @requirements REQ-109
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildWeekUrl, advanceCursor, parseScheduleHtml, runScheduleSync, runDetailSync } from '../../lib/scraper/syncRunner.js';
+
+// ─── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../../lib/scraper/auth.js', () => ({
+  setSession: vi.fn(),
+  authenticatedFetch: vi.fn(),
+}));
+
+vi.mock('../../lib/scraper/sessionCache.js', () => ({
+  ensureSession: vi.fn(),
+  clearSession: vi.fn(),
+}));
+
+vi.mock('../../lib/scraper/syncQueue.js', () => ({
+  enqueue: vi.fn(),
+  dequeueOne: vi.fn(),
+  markDone: vi.fn(),
+  markFailed: vi.fn(),
+  resetStuck: vi.fn(),
+  getQueueDepth: vi.fn(),
+}));
+
+vi.mock('../../lib/scraper/daytimeSchedule.js', () => ({
+  parseDaytimeSchedulePage: vi.fn(() => []),
+  upsertDaytimeAppointments: vi.fn(() => ({ upserted: 0, errors: 0 })),
+}));
+
+vi.mock('../../lib/scraper/extraction.js', () => ({
+  fetchAppointmentDetails: vi.fn(),
+}));
+
+vi.mock('../../lib/scraper/mapping.js', () => ({
+  mapAndSaveAppointment: vi.fn(),
+}));
+
+vi.mock('../../lib/scraper/forms.js', () => ({
+  fetchAndStoreBoardingForm: vi.fn(),
+}));
+
+import { setSession, authenticatedFetch } from '../../lib/scraper/auth.js';
+import { ensureSession, clearSession } from '../../lib/scraper/sessionCache.js';
+import { dequeueOne, markDone, resetStuck, getQueueDepth } from '../../lib/scraper/syncQueue.js';
+import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from '../../lib/scraper/daytimeSchedule.js';
+import { fetchAppointmentDetails } from '../../lib/scraper/extraction.js';
+import { mapAndSaveAppointment } from '../../lib/scraper/mapping.js';
+
+// ─── Minimal supabase mock ─────────────────────────────────────────────────────
+
+function makeMockSupabase() {
+  return {
+    from: () => ({
+      select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: null, error: null }) }) }),
+      update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      insert: () => Promise.resolve({ error: null }),
+    }),
+  };
+}
+
+// ─── buildWeekUrl ─────────────────────────────────────────────────────────────
+
+describe('buildWeekUrl', () => {
+  it('builds the correct schedule URL for a given date', () => {
+    const date = new Date(2026, 2, 20); // March 20, 2026 (month is 0-indexed)
+    const url = buildWeekUrl(date);
+    expect(url).toMatch(/\/schedule\/days-7\/2026\/3\/20$/);
+  });
+
+  it('omits leading zeros from month and day (AGYD URL format)', () => {
+    const date = new Date(2026, 0, 5); // January 5
+    const url = buildWeekUrl(date);
+    expect(url).toMatch(/\/schedule\/days-7\/2026\/1\/5$/);
+  });
+});
+
+// ─── advanceCursor ────────────────────────────────────────────────────────────
+
+describe('advanceCursor', () => {
+  it('advances the cursor by exactly 7 days', () => {
+    const cursor = new Date(2026, 2, 1); // March 1
+    const next = advanceCursor(cursor);
+    expect(next.getDate()).toBe(8);
+    expect(next.getMonth()).toBe(2); // still March
+  });
+
+  it('wraps back to today when the cursor would exceed today + 56 days', () => {
+    const farFuture = new Date();
+    farFuture.setDate(farFuture.getDate() + 60); // 60 days out, beyond 8-week window
+    const next = advanceCursor(farFuture);
+    const today = new Date();
+    // next should be approximately today (within same day)
+    expect(next.toDateString()).toBe(today.toDateString());
+  });
+
+  it('does NOT wrap when cursor is within the 8-week window', () => {
+    const withinWindow = new Date();
+    withinWindow.setDate(withinWindow.getDate() + 14); // 2 weeks out
+    const next = advanceCursor(withinWindow);
+    const expected = new Date(withinWindow);
+    expected.setDate(expected.getDate() + 7);
+    expect(next.toDateString()).toBe(expected.toDateString());
+  });
+});
+
+// ─── parseScheduleHtml ────────────────────────────────────────────────────────
+
+describe('parseScheduleHtml', () => {
+  it('returns empty array for HTML with no schedule links', () => {
+    expect(parseScheduleHtml('<html><body>no links</body></html>')).toEqual([]);
+  });
+
+  it('extracts id, title, petName, and petIds from a schedule link', () => {
+    const html = `
+      <a href="/schedule/a/C63QgY32/1742342400" class="day-event">
+        <span class="day-event-title">Buddy Boarding</span>
+        <span class="event-pet" data-pet="90043">Buddy</span>
+        <div class="event-pet-wrapper" data-pet="90043"></div>
+      </a>
+    `;
+    const results = parseScheduleHtml(html);
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('C63QgY32');
+    expect(results[0].title).toBe('Buddy Boarding');
+    expect(results[0].petName).toBe('Buddy');
+    expect(results[0].petIds).toContain('90043');
+    expect(results[0].url).toContain('/schedule/a/C63QgY32/');
+  });
+
+  it('deduplicates appointments with the same id', () => {
+    const link = `<a href="/schedule/a/DUPEID/111"><span class="day-event-title">Buddy</span></a>`;
+    const html = link + link; // same id twice
+    const results = parseScheduleHtml(html);
+    expect(results).toHaveLength(1);
+  });
+});
+
+// ─── runScheduleSync — session_failed branch ──────────────────────────────────
+
+describe('runScheduleSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getQueueDepth.mockResolvedValue(0);
+    upsertDaytimeAppointments.mockResolvedValue({ upserted: 0, errors: 0 });
+    parseDaytimeSchedulePage.mockReturnValue([]);
+  });
+
+  it('returns action=session_failed when ensureSession throws', async () => {
+    ensureSession.mockRejectedValue(new Error('No credentials configured'));
+    const result = await runScheduleSync(makeMockSupabase());
+    expect(result.action).toBe('session_failed');
+    expect(result.error).toMatch(/No credentials/);
+    expect(result.pagesScanned).toBe(0);
+  });
+
+  it('returns action=session_cleared when SESSION_EXPIRED is detected on page fetch', async () => {
+    ensureSession.mockResolvedValue('session=abc');
+    setSession.mockReturnValue(undefined);
+    // authenticatedFetch returns a response whose text includes login/password markers
+    authenticatedFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('<html>login password</html>'),
+    });
+    // supabase mock needs to support getCursorDate (single) and clearSession calls
+    const supabase = {
+      from: () => ({
+        select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: null, error: null }) }) }),
+        update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        insert: () => Promise.resolve({ error: null }),
+        delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      }),
+    };
+    clearSession.mockResolvedValue(undefined);
+    const result = await runScheduleSync(supabase);
+    expect(result.action).toBe('session_cleared');
+    expect(clearSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns action=ok with stats on successful scan with no boardings', async () => {
+    ensureSession.mockResolvedValue('session=abc');
+    setSession.mockReturnValue(undefined);
+    // Return HTML with no matching appointment links
+    authenticatedFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('<html><body>empty schedule</body></html>'),
+    });
+    const supabase = {
+      from: (table) => {
+        if (table === 'sync_settings') {
+          return {
+            select: () => ({
+              limit: () => ({
+                single: () => Promise.resolve({ data: { id: '1', schedule_cursor_date: '2026-03-01' }, error: null }),
+              }),
+            }),
+            update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+            insert: () => Promise.resolve({ error: null }),
+          };
+        }
+        return {
+          select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: null, error: null }) }) }),
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+          insert: () => Promise.resolve({ error: null }),
+        };
+      },
+    };
+    getQueueDepth.mockResolvedValue(0);
+    const result = await runScheduleSync(supabase);
+    expect(result.action).toBe('ok');
+    expect(result.found).toBe(0);
+    expect(result.queued).toBe(0);
+  });
+});
+
+// ─── runDetailSync — key branches ─────────────────────────────────────────────
+
+describe('runDetailSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ensureSession.mockResolvedValue('session=abc');
+    setSession.mockReturnValue(undefined);
+    resetStuck.mockResolvedValue(0);
+    getQueueDepth.mockResolvedValue(0);
+  });
+
+  it('returns action=session_failed when ensureSession throws', async () => {
+    ensureSession.mockRejectedValue(new Error('Auth failed'));
+    const result = await runDetailSync(makeMockSupabase());
+    expect(result.action).toBe('session_failed');
+    expect(result.error).toMatch(/Auth failed/);
+  });
+
+  it('returns action=idle when queue is empty', async () => {
+    dequeueOne.mockResolvedValue(null);
+    const result = await runDetailSync(makeMockSupabase());
+    expect(result.action).toBe('idle');
+  });
+
+  it('calls resetStuck when runResetStuck is true (default)', async () => {
+    dequeueOne.mockResolvedValue(null);
+    await runDetailSync(makeMockSupabase());
+    expect(resetStuck).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips resetStuck when runResetStuck is false', async () => {
+    dequeueOne.mockResolvedValue(null);
+    await runDetailSync(makeMockSupabase(), { runResetStuck: false });
+    expect(resetStuck).not.toHaveBeenCalled();
+  });
+
+  it('returns action=created after successfully processing an appointment', async () => {
+    dequeueOne.mockResolvedValue({
+      id: 'queue-1',
+      external_id: 'C63QgY32',
+      source_url: 'https://agirlandyourdog.com/schedule/a/C63QgY32/1742342400',
+      title: 'Buddy',
+      type: 'appointment',
+      meta: { external_pet_id: '90043' },
+      retry_count: 0,
+    });
+    fetchAppointmentDetails.mockResolvedValue({
+      external_id: 'C63QgY32',
+      pet_name: 'Buddy',
+      arrival_date: '2026-03-20',
+    });
+    mapAndSaveAppointment.mockResolvedValue({ stats: { syncCreated: true, syncUpdated: false, dogUpdated: false, boardingUpdated: false } });
+    markDone.mockResolvedValue(undefined);
+    getQueueDepth.mockResolvedValue(0);
+
+    const result = await runDetailSync(makeMockSupabase());
+    expect(result.action).toBe('created');
+    expect(result.externalId).toBe('C63QgY32');
+    expect(markDone).toHaveBeenCalledWith(expect.anything(), 'queue-1');
+  });
+
+  it('returns action=session_cleared and re-queues item on SESSION_EXPIRED during fetch', async () => {
+    dequeueOne.mockResolvedValue({
+      id: 'queue-2',
+      external_id: 'C63QgY99',
+      source_url: 'https://agirlandyourdog.com/schedule/a/C63QgY99/111',
+      title: 'Max',
+      type: 'appointment',
+      meta: {},
+      retry_count: 0,
+    });
+    fetchAppointmentDetails.mockRejectedValue(new Error('Session expired — please re-authenticate'));
+    clearSession.mockResolvedValue(undefined);
+
+    const supabase = {
+      from: () => ({
+        select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: null, error: null }) }) }),
+        update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        insert: () => Promise.resolve({ error: null }),
+      }),
+    };
+
+    const result = await runDetailSync(supabase);
+    expect(result.action).toBe('session_cleared');
+    expect(clearSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/scraper/syncRunner.js
+++ b/src/lib/scraper/syncRunner.js
@@ -1,0 +1,514 @@
+/**
+ * syncRunner — shared schedule-scan and detail-processing logic.
+ *
+ * This module extracts the core sync operations from the Vercel cron handler
+ * wrappers so they can be called from multiple entry points:
+ *   - api/cron-schedule.js  — Vercel cron (thin wrapper)
+ *   - api/cron-detail.js    — Vercel cron (thin wrapper)
+ *   - scripts/integration-check.js — Step 0 sync-before-compare
+ *
+ * DESIGN RULES (do not violate):
+ *   - Both runners accept `supabase` as a parameter. They never instantiate
+ *     their own client. The caller controls the key scope (must be service role).
+ *   - Neither runner calls writeCronHealth. Health tracking is the Vercel
+ *     handler's responsibility. Calling it from integration-check would
+ *     overwrite the midnight cron's health record.
+ *   - NON_BOARDING_RE is NOT exported for use by integration-check.js.
+ *     integration-check.js defines its own copy independently to preserve
+ *     signal isolation. See integration-check.js comment for rationale.
+ *
+ * SIDE EFFECT — setSession:
+ *   runScheduleSync calls setSession(cookies) on the auth module, which sets
+ *   module-level state used by authenticatedFetch. This is intentional and safe
+ *   in a single-process Node.js context (no concurrency). Be aware that any
+ *   subsequent authenticatedFetch calls in the same process will use these
+ *   cookies. In Vercel serverless each invocation is isolated, so no conflict.
+ *
+ * CURSOR ADVANCE SIDE EFFECT:
+ *   runScheduleSync advances schedule_cursor_date in sync_settings every call.
+ *   When called from the integration check (3×/day), the cursor advances 3
+ *   extra times beyond the midnight cron. The cursor cycles over 8 weeks so
+ *   this is functionally harmless, but the cursor no longer cleanly represents
+ *   "how far the midnight cron has advanced." Acceptable tradeoff.
+ *
+ * ENQUEUE IDEMPOTENCY:
+ *   enqueue() silently skips items already pending, processing, or done.
+ *   It is safe to call runScheduleSync on a schedule that was already scanned
+ *   tonight — duplicate external_ids will be skipped without error.
+ *
+ * @requirements REQ-109
+ */
+
+import { setSession } from './auth.js';
+import { authenticatedFetch } from './auth.js';
+import { ensureSession, clearSession } from './sessionCache.js';
+import { enqueue, dequeueOne, markDone, markFailed, resetStuck as resetStuckItems, getQueueDepth } from './syncQueue.js';
+import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from './daytimeSchedule.js';
+import { fetchAppointmentDetails } from './extraction.js';
+import { mapAndSaveAppointment } from './mapping.js';
+import { fetchAndStoreBoardingForm } from './forms.js';
+
+const BASE_URL = process.env.VITE_EXTERNAL_SITE_URL || 'https://agirlandyourdog.com';
+const CURSOR_WINDOW_WEEKS = 8;
+
+// Known non-boarding title patterns — mirrors sync.js pre-filter.
+// NOT exported — integration-check.js defines its own copy for signal isolation.
+const NON_BOARDING_RE = [
+  /(d\/c|\bdc\b)/i,
+  /(p\/g|g\/p|\bpg\b)/i,
+  /\badd\b/i,
+  /switch\s+day/i,
+  /back\s+to\s+\d+/i,
+  /initial\s+eval/i,
+  /^busy$/i,
+];
+
+// ---------------------------------------------------------------------------
+// Schedule helpers (previously private in cron-schedule.js)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the schedule URL for a specific week start date.
+ * /schedule/days-7/YYYY/M/D
+ *
+ * @param {Date} date
+ * @returns {string}
+ */
+export function buildWeekUrl(date) {
+  const y = date.getFullYear();
+  const m = date.getMonth() + 1;
+  const d = date.getDate();
+  return `${BASE_URL}/schedule/days-7/${y}/${m}/${d}`;
+}
+
+/**
+ * Advance the cursor by 7 days.
+ * Wraps back to today when the cursor would exceed today + CURSOR_WINDOW_WEEKS weeks.
+ *
+ * @param {Date} cursor
+ * @returns {Date}
+ */
+export function advanceCursor(cursor) {
+  const maxDate = new Date();
+  maxDate.setDate(maxDate.getDate() + CURSOR_WINDOW_WEEKS * 7);
+
+  const next = new Date(cursor);
+  next.setDate(next.getDate() + 7);
+
+  return next > maxDate ? new Date() : next;
+}
+
+/**
+ * Fetch one schedule page and return its raw HTML.
+ * Throws with message 'SESSION_EXPIRED' if the site serves a login page.
+ *
+ * @param {Date} date
+ * @returns {Promise<string>}
+ */
+async function fetchScheduleHtml(date) {
+  const url = buildWeekUrl(date);
+  console.log(`[SyncRunner:Schedule] Fetching ${date.toDateString()} — url: ${url}`);
+  const response = await authenticatedFetch(url);
+  if (!response.ok) throw new Error(`Schedule fetch failed: ${response.status}`);
+  const html = await response.text();
+  if (html.includes('login') && html.includes('password')) {
+    throw new Error('SESSION_EXPIRED');
+  }
+  return html;
+}
+
+/**
+ * Extract appointment links from schedule page HTML using regex.
+ * No DOMParser required — safe for Node.js runtime.
+ *
+ * Returns objects with: { id, url, timestamp, petName, clientName, time, title, petIds }
+ *
+ * @param {string} html
+ * @returns {Array<Object>}
+ */
+export function parseScheduleHtml(html) {
+  const results = [];
+  const seen = new Set();
+
+  const blockRe = /<a\b([^>]+href="[^"]*\/schedule\/a\/[^"]*"[^>]*)>([\s\S]*?)<\/a>/gi;
+  let m;
+
+  while ((m = blockRe.exec(html)) !== null) {
+    const attrs = m[1];
+    const inner = m[2];
+
+    const hrefMatch = attrs.match(/href="([^"]+)"/);
+    if (!hrefMatch) continue;
+
+    const href = hrefMatch[1];
+    const urlMatch = href.match(/\/schedule\/a\/([^/]+)\/(\d+)/);
+    if (!urlMatch) continue;
+
+    const id = urlMatch[1];
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const pick = (cls) => {
+      const r = inner.match(new RegExp(`class="[^"]*${cls}[^"]*"[^>]*>([^<]*)<`));
+      return r ? r[1].trim() : '';
+    };
+
+    const petIds = [];
+    const petIdRe = /data-pet="([^"]+)"/g;
+    let petMatch;
+    while ((petMatch = petIdRe.exec(inner)) !== null) {
+      petIds.push(petMatch[1]);
+    }
+
+    const fullUrl = href.startsWith('http') ? href : `${BASE_URL}${href}`;
+    results.push({
+      id,
+      url: fullUrl,
+      timestamp: urlMatch[2],
+      petName: pick('event-pet'),
+      clientName: pick('event-client'),
+      time: pick('day-event-time'),
+      title: pick('day-event-title'),
+      petIds,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Read the current cursor date from sync_settings.
+ * Returns today if not set.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<Date>}
+ */
+async function getCursorDate(supabase) {
+  const { data } = await supabase
+    .from('sync_settings')
+    .select('schedule_cursor_date')
+    .limit(1)
+    .single();
+
+  if (data?.schedule_cursor_date) {
+    const [y, mo, d] = data.schedule_cursor_date.split('-').map(Number);
+    return new Date(y, mo - 1, d);
+  }
+  return new Date();
+}
+
+/**
+ * Persist the cursor date in sync_settings.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Date} date
+ */
+async function saveCursorDate(supabase, date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  const isoDate = `${y}-${m}-${d}`;
+
+  const { data: existing } = await supabase
+    .from('sync_settings')
+    .select('id')
+    .limit(1)
+    .single();
+
+  if (existing) {
+    await supabase
+      .from('sync_settings')
+      .update({ schedule_cursor_date: isoDate })
+      .eq('id', existing.id);
+  } else {
+    await supabase
+      .from('sync_settings')
+      .insert({ schedule_cursor_date: isoDate });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported runners
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan schedule pages, enqueue boarding candidates, and upsert daytime events.
+ *
+ * Fetches three pages per call (current week, next week, cursor week) and
+ * advances the rotating cursor. Handles SESSION_EXPIRED by clearing the
+ * cached session and returning early with action='session_cleared'.
+ *
+ * Does NOT call writeCronHealth — callers are responsible for health tracking.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ *   Must use the service role key — reads session_cookies from sync_settings.
+ * @returns {Promise<{
+ *   action: 'ok'|'session_failed'|'session_cleared',
+ *   pagesScanned: number,
+ *   found: number,
+ *   skipped: number,
+ *   queued: number,
+ *   daytimeUpserted: number,
+ *   daytimeErrors: number,
+ *   cursorAdvancedTo: string,
+ *   queueDepth: number,
+ *   error?: string,
+ * }>}
+ */
+export async function runScheduleSync(supabase) {
+  console.log('[SyncRunner:Schedule] Starting schedule sync');
+
+  // Ensure we have a valid session — re-authenticates if cache is missing/expired.
+  // Requires EXTERNAL_SITE_USERNAME + EXTERNAL_SITE_PASSWORD in env when re-auth is needed.
+  let cookies;
+  try {
+    cookies = await ensureSession(supabase);
+  } catch (sessionErr) {
+    console.error('[SyncRunner:Schedule] ❌ Could not obtain session:', sessionErr.message);
+    return { action: 'session_failed', error: sessionErr.message, pagesScanned: 0, found: 0, skipped: 0, queued: 0, daytimeUpserted: 0, daytimeErrors: 0, cursorAdvancedTo: '', queueDepth: 0 };
+  }
+
+  // Sets module-level state in auth.js used by authenticatedFetch (intentional — see module JSDoc).
+  setSession(cookies);
+
+  const cursorDate = await getCursorDate(supabase);
+  const today = new Date();
+  console.log(`[SyncRunner:Schedule] 📅 Cursor: ${cursorDate.toDateString()}`);
+
+  const stats = { pagesScanned: 0, found: 0, skipped: 0, queued: 0, daytimeUpserted: 0, daytimeErrors: 0 };
+
+  const datesToFetch = [today];
+  const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+  datesToFetch.push(nextWeek);
+
+  const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  const sameAsToday    = Math.abs(cursorDate - today)    < ONE_WEEK_MS;
+  const sameAsNextWeek = Math.abs(cursorDate - nextWeek) < ONE_WEEK_MS;
+  if (!sameAsToday && !sameAsNextWeek) datesToFetch.push(cursorDate);
+
+  const seenIds = new Set();
+  const appointments = [];
+  const allDaytimeAppts = [];
+
+  for (const date of datesToFetch) {
+    let html;
+    try {
+      html = await fetchScheduleHtml(date);
+    } catch (err) {
+      if (err.message === 'SESSION_EXPIRED') {
+        console.log('[SyncRunner:Schedule] 🔒 SESSION_EXPIRED detected — clearing cached session');
+        await clearSession(supabase);
+        return { action: 'session_cleared', reason: 'session_expired', pagesScanned: stats.pagesScanned, found: 0, skipped: 0, queued: 0, daytimeUpserted: 0, daytimeErrors: 0, cursorAdvancedTo: '', queueDepth: 0 };
+      }
+      throw err;
+    }
+
+    const parsed = parseScheduleHtml(html);
+    stats.pagesScanned++;
+    console.log(`[SyncRunner:Schedule] 📋 ${parsed.length} appointments on ${date.toDateString()}`);
+
+    for (const appt of parsed) {
+      if (seenIds.has(appt.id)) continue;
+      seenIds.add(appt.id);
+      appointments.push(appt);
+    }
+
+    const daytimeAppts = parseDaytimeSchedulePage(html);
+    console.log(`[SyncRunner:Schedule] 🏃 ${daytimeAppts.length} daytime events on ${date.toDateString()}`);
+    allDaytimeAppts.push(...daytimeAppts);
+  }
+
+  stats.found = appointments.length;
+
+  for (const appt of appointments) {
+    const titleLower = (appt.title || '').toLowerCase().trim();
+    const matchedPattern = NON_BOARDING_RE.find(re => re.test(titleLower));
+
+    if (matchedPattern) {
+      console.log(`[SyncRunner:Schedule] ⏭️ SKIP ${appt.id} — matched NON_BOARDING_RE ${matchedPattern}`);
+      stats.skipped++;
+      continue;
+    }
+
+    console.log(`[SyncRunner:Schedule] 📥 ENQUEUE ${appt.id} title="${appt.title}"`);
+    try {
+      await enqueue(supabase, {
+        external_id: appt.id,
+        source_url: appt.url,
+        title: appt.title || appt.petName || '',
+        meta: appt.petIds?.[0] ? { external_pet_id: appt.petIds[0] } : {},
+      });
+      stats.queued++;
+    } catch (err) {
+      console.error(`[SyncRunner:Schedule] ⚠️ Enqueue failed for ${appt.id}: ${err.message}`);
+    }
+  }
+
+  console.log(`[SyncRunner:Schedule] 🐕 ${stats.found} found, ${stats.skipped} skipped, ${stats.queued} queued`);
+
+  const daytimeResult = await upsertDaytimeAppointments(supabase, allDaytimeAppts);
+  stats.daytimeUpserted = daytimeResult.upserted;
+  stats.daytimeErrors = daytimeResult.errors;
+  console.log(`[SyncRunner:Schedule] 📊 Daytime upserted: ${daytimeResult.upserted}, errors: ${daytimeResult.errors}`);
+
+  const nextCursor = advanceCursor(cursorDate);
+  await saveCursorDate(supabase, nextCursor);
+  const wrapped = nextCursor <= today;
+  console.log(wrapped
+    ? '[SyncRunner:Schedule] 🔄 Cursor wrapped back to today'
+    : `[SyncRunner:Schedule] ➡️ Cursor: ${cursorDate.toDateString()} → ${nextCursor.toDateString()}`
+  );
+
+  const queueDepth = await getQueueDepth(supabase);
+  console.log(`[SyncRunner:Schedule] 📊 Queue depth after scan: ${queueDepth} pending`);
+
+  return {
+    action: 'ok',
+    pagesScanned: stats.pagesScanned,
+    found: stats.found,
+    skipped: stats.skipped,
+    queued: stats.queued,
+    daytimeUpserted: stats.daytimeUpserted,
+    daytimeErrors: stats.daytimeErrors,
+    cursorAdvancedTo: nextCursor.toISOString().slice(0, 10),
+    queueDepth,
+  };
+}
+
+/**
+ * Dequeue and process one item from the sync queue.
+ *
+ * Handles both appointment jobs and form jobs. Returns the action taken so
+ * callers can loop until action === 'idle' to drain the queue.
+ *
+ * Does NOT call writeCronHealth — callers are responsible for health tracking.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ *   Must use the service role key.
+ * @param {{ runResetStuck?: boolean }} [options]
+ *   runResetStuck (default true): whether to reset stuck 'processing' items
+ *   before dequeuing. Pass false when looping to avoid redundant DB queries
+ *   on every iteration — the caller should call resetStuck once before the loop.
+ * @returns {Promise<{
+ *   action: 'idle'|'created'|'updated'|'unchanged'|'form_stored'|'skipped'|'failed'|'form_failed'|'save_failed'|'session_failed'|'session_cleared',
+ *   externalId?: string,
+ *   queueDepth?: number,
+ *   error?: string,
+ *   reason?: string,
+ * }>}
+ */
+export async function runDetailSync(supabase, { runResetStuck = true } = {}) {
+  // Ensure session before dequeuing so we never need to put an item back on auth failure.
+  let cookies;
+  try {
+    cookies = await ensureSession(supabase);
+  } catch (sessionErr) {
+    console.error('[SyncRunner:Detail] ❌ Could not obtain session:', sessionErr.message);
+    return { action: 'session_failed', error: sessionErr.message };
+  }
+
+  setSession(cookies);
+
+  // Reset stuck items — only needed on the first call in a loop, not every iteration.
+  if (runResetStuck) {
+    const resetCount = await resetStuckItems(supabase);
+    if (resetCount > 0) {
+      console.log(`[SyncRunner:Detail] ⚠️ Reset ${resetCount} stuck item(s) to pending`);
+    }
+  }
+
+  const item = await dequeueOne(supabase);
+  if (!item) {
+    console.log('[SyncRunner:Detail] 📭 Queue empty — idle');
+    return { action: 'idle' };
+  }
+
+  const itemType = item.type || 'appointment';
+  const depth = await getQueueDepth(supabase);
+  console.log(`[SyncRunner:Detail] 🐕 Processing 1 of ${depth + 1} queued: ${item.external_id} (type=${itemType}, retry=${item.retry_count ?? 0}/3)`);
+  console.log(`[SyncRunner:Detail]    source_url: ${item.source_url}`);
+
+  // ── Form fetch job ────────────────────────────────────────────────────────
+  if (itemType === 'form') {
+    const { boarding_id: boardingId, external_pet_id: externalPetId } = item.meta || {};
+
+    if (!externalPetId) {
+      console.log(`[SyncRunner:Detail] ⏭️ SKIP form ${item.external_id} — no external_pet_id (pre-v3 queue item)`);
+      await markDone(supabase, item.id);
+      const remaining = await getQueueDepth(supabase);
+      return { action: 'skipped', reason: 'no_pet_id', externalId: item.external_id, queueDepth: remaining };
+    }
+
+    console.log(`[SyncRunner:Detail] 📋 Form job: boarding_id=${boardingId}, pet_id=${externalPetId}`);
+
+    try {
+      await fetchAndStoreBoardingForm(supabase, boardingId, externalPetId, item.title || '');
+      await markDone(supabase, item.id);
+      const remaining = await getQueueDepth(supabase);
+      console.log(`[SyncRunner:Detail] ✅ Form stored for boarding ${boardingId} — queue depth: ${remaining}`);
+      return { action: 'form_stored', externalId: item.external_id, queueDepth: remaining };
+    } catch (formErr) {
+      if (formErr.message && formErr.message.includes('Session expired')) {
+        console.log('[SyncRunner:Detail] 🔒 SESSION_EXPIRED during form fetch — clearing session + re-queuing item');
+        await clearSession(supabase);
+        await supabase
+          .from('sync_queue')
+          .update({ status: 'pending', processing_started_at: null })
+          .eq('id', item.id);
+        return { action: 'session_cleared', reason: 'session_expired' };
+      }
+      const msg = formErr.message.slice(0, 200);
+      console.error(`[SyncRunner:Detail] ❌ Form fetch failed (retry ${(item.retry_count || 0) + 1}/3): ${msg}`);
+      await markFailed(supabase, item.id, msg);
+      const remaining = await getQueueDepth(supabase);
+      return { action: 'form_failed', error: msg, externalId: item.external_id, queueDepth: remaining };
+    }
+  }
+
+  // ── Appointment job (default) ─────────────────────────────────────────────
+  const urlMatch = item.source_url.match(/\/schedule\/a\/([^/]+)\/(\d+)/);
+  const [, appointmentId, timestamp] = urlMatch || [null, item.external_id, ''];
+  const externalPetId = item.meta?.external_pet_id || null;
+
+  let details;
+  try {
+    details = await fetchAppointmentDetails(appointmentId, timestamp);
+  } catch (err) {
+    if (err.message && err.message.includes('Session expired')) {
+      console.log('[SyncRunner:Detail] 🔒 SESSION_EXPIRED during detail fetch — clearing session + re-queuing item');
+      await clearSession(supabase);
+      await supabase
+        .from('sync_queue')
+        .update({ status: 'pending', processing_started_at: null })
+        .eq('id', item.id);
+      return { action: 'session_cleared', reason: 'session_expired' };
+    }
+    const msg = err.message.slice(0, 200);
+    console.error(`[SyncRunner:Detail] ❌ Fetch failed (retry ${(item.retry_count || 0) + 1}/3): ${msg}`);
+    await markFailed(supabase, item.id, msg);
+    const remaining = await getQueueDepth(supabase);
+    return { action: 'failed', error: msg, externalId: item.external_id, queueDepth: remaining };
+  }
+
+  if (!details.pet_name && item.title) details.pet_name = item.title;
+
+  try {
+    const saveResult = await mapAndSaveAppointment(details, { supabase, externalPetId });
+    await markDone(supabase, item.id);
+
+    const { stats } = saveResult;
+    const action = stats.syncCreated ? 'created'
+      : stats.syncUpdated || stats.dogUpdated || stats.boardingUpdated ? 'updated'
+      : 'unchanged';
+
+    const remaining = await getQueueDepth(supabase);
+    console.log(`[SyncRunner:Detail] ✅ ${details.pet_name || details.external_id} → ${action} — queue depth: ${remaining}`);
+    return { action, externalId: item.external_id, queueDepth: remaining };
+  } catch (saveErr) {
+    const msg = saveErr.message.slice(0, 200);
+    console.error(`[SyncRunner:Detail] ❌ Save failed (retry ${(item.retry_count || 0) + 1}/3): ${msg}`);
+    await markFailed(supabase, item.id, msg);
+    const remaining = await getQueueDepth(supabase);
+    return { action: 'save_failed', error: msg, externalId: item.external_id, queueDepth: remaining };
+  }
+}


### PR DESCRIPTION
## Summary

- **New `src/lib/scraper/syncRunner.js`** — extracts `runScheduleSync` and `runDetailSync` from the Vercel cron handlers. Single source of truth for sync logic; Vercel handlers are now thin wrappers with no behavior change.
- **Integration check Step 0** — runs schedule sync + drains detail queue (max 20 iterations) before Playwright compare. Eliminates the known false positive where bookings made after midnight UTC appear as "Missing from DB" at the 1am check. Non-fatal: if Step 0 fails, check continues with current DB state.
- **Gap fixes from design review:** `resetStuck` called once before the detail loop (not 20×); `EXTERNAL_SITE_USERNAME`/`PASSWORD` wired into workflow for Step 0 re-auth on session expiry; dead `SKIP_SYNC` env var and `APP_URL`/`VITE_SYNC_PROXY_TOKEN` removed from workflow.
- **17 new tests** — `buildWeekUrl`, `advanceCursor`, `parseScheduleHtml`, and key runner branches (session_failed, session_cleared, idle, created, session_cleared-on-fetch)
- **775 tests, 0 failures, 100% requirements coverage**

## ⚠️ Action required before merging

Add two GH repo secrets (Settings → Secrets → Actions → Repository secrets). Values are the same as the Vercel env vars:
- `EXTERNAL_SITE_USERNAME`
- `EXTERNAL_SITE_PASSWORD`

Without them, Step 0 still runs but can't re-auth on session expiry (degrades gracefully).

## Test plan

- [ ] Add `EXTERNAL_SITE_USERNAME` + `EXTERNAL_SITE_PASSWORD` as GH repo secrets
- [ ] CI passes on this PR
- [ ] After merge: trigger integration check manually via Actions → Integration Check → Run workflow
- [ ] Confirm Step 0 log lines appear: `[IntegCheck] Step 0: running sync-before-compare`
- [ ] Confirm Step 0 detail loop logs: `[IntegCheck] Step 0 detail [1/20]: action=idle queueDepth=0`
- [ ] Tag v4.4.3 after merge
