### PR TITLE
feat: v5.0 infra — Meta WhatsApp, cron health check, Gmail monitor

### DIFF
--- a/.github/workflows/cron-health-check.yml
+++ b/.github/workflows/cron-health-check.yml
@@ -1,0 +1,45 @@
+# Cron health check — verifies the midnight Vercel crons (auth, schedule, detail) ran.
+#
+# Runs at 00:30 UTC — 30 minutes after cron-auth fires at 00:00 UTC, giving the
+# full cron chain time to complete before we check.
+#
+# Sends a WhatsApp alert to INTEGRATION_CHECK_RECIPIENTS when:
+#   - Any cron did not run since midnight UTC
+#   - Any cron shows 2 consecutive failures in cron_health_log
+#
+# Required Repository secrets:
+#   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+#   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
+#   INTEGRATION_CHECK_RECIPIENTS
+name: Cron Health Check
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 00:30 UTC daily — 30 min after midnight crons
+    - cron: '30 0 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run cron health check
+        run: node scripts/cron-health-check.js
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}
+          INTEGRATION_CHECK_RECIPIENTS: ${{ secrets.INTEGRATION_CHECK_RECIPIENTS }}

--- a/.github/workflows/gmail-monitor.yml
+++ b/.github/workflows/gmail-monitor.yml
@@ -1,0 +1,59 @@
+# Gmail monitor — scans kcoffie@gmail.com for infrastructure failure emails
+# and sends a WhatsApp alert to INTEGRATION_CHECK_RECIPIENTS.
+#
+# Monitors for:
+#   - GitHub Actions workflow failures (notifications@github.com)
+#   - Vercel deployment failures (notifications@vercel.com)
+#   - Any email from *@supabase.com
+#
+# Subject-based filtering prevents false positives from GitHub PR comments,
+# Vercel preview deployment success emails, etc.
+#
+# Required Repository secrets:
+#   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+#   GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN
+#   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
+#   INTEGRATION_CHECK_RECIPIENTS
+#   ANTHROPIC_API_KEY (optional — used for 1-line email summaries; falls back to subject)
+#
+# Kate-actions required before first run:
+#   1. Create Google Cloud project + enable Gmail API
+#   2. Create OAuth2 credentials (web app type)
+#   3. Run one-time auth script locally → capture GMAIL_REFRESH_TOKEN
+#   4. Add GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN to GH secrets
+name: Gmail Monitor
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every hour at :15 past (offset from other hourly jobs)
+    - cron: '15 * * * *'
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Gmail monitor
+        run: node scripts/gmail-monitor.js
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
+          TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+          TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          TWILIO_FROM_NUMBER: ${{ secrets.TWILIO_FROM_NUMBER }}
+          INTEGRATION_CHECK_RECIPIENTS: ${{ secrets.INTEGRATION_CHECK_RECIPIENTS }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/api/cron-auth.js
+++ b/api/cron-auth.js
@@ -50,6 +50,10 @@ export default async function handler(req, res) {
     console.log('[CronAuth] 🔐 Starting auth refresh (unconditional)');
     const supabase = getSupabase();
 
+    // Write 'started' immediately so the health checker can detect hard crashes
+    // (where the cron exits before writing success/failure).
+    await writeCronHealth(supabase, 'auth', 'started', { action: 'running' }, null);
+
     const username = process.env.EXTERNAL_SITE_USERNAME;
     const password = process.env.EXTERNAL_SITE_PASSWORD;
     if (!username || !password) {

--- a/api/cron-detail.js
+++ b/api/cron-detail.js
@@ -42,6 +42,9 @@ export default async function handler(req, res) {
   try {
     const supabase = getSupabase();
 
+    // Write 'started' immediately so the health checker can detect hard crashes.
+    await writeCronHealth(supabase, 'detail', 'started', { action: 'running' }, null);
+
     // Reset stuck items before processing. runDetailSync is called with
     // runResetStuck: false because we handle it here explicitly (single call,
     // no loop — no redundancy concern). This matches pre-refactor behavior.

--- a/api/cron-schedule.js
+++ b/api/cron-schedule.js
@@ -45,6 +45,10 @@ export default async function handler(req, res) {
 
   try {
     const supabase = getSupabase();
+
+    // Write 'started' immediately so the health checker can detect hard crashes.
+    await writeCronHealth(supabase, 'schedule', 'started', { action: 'running' }, null);
+
     const result = await runScheduleSync(supabase);
 
     if (result.action === 'session_failed') {

--- a/api/notify.js
+++ b/api/notify.js
@@ -17,9 +17,9 @@
  * deployment URL (production, preview, local). Twilio fetches the image from
  * our own /api/roster-image endpoint at delivery time.
  *
- * Runs on Node.js runtime — Twilio SDK requires Node.js.
+ * Runs on Node.js runtime — required by the Meta fetch calls and Supabase client.
  *
- * @requirements REQ-v4.1
+ * @requirements REQ-v4.1, REQ-v5.0-M0
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -29,123 +29,18 @@ import {
   shouldSendNotification,
 } from '../src/lib/pictureOfDay.js';
 import {
-  createTwilioClient,
   sendRosterImage,
+  sendTextMessage,
   getRecipients,
 } from '../src/lib/notifyWhatsApp.js';
 import { writeCronHealth } from './_cronHealth.js';
-import { ensureSession, clearSession } from '../src/lib/scraper/sessionCache.js';
-import { setSession, authenticatedFetch } from '../src/lib/scraper/auth.js';
-import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from '../src/lib/scraper/daytimeSchedule.js';
+import { refreshDaytimeSchedule } from '../src/lib/notifyHelpers.js';
 
 export const config = { runtime: 'nodejs' };
 
 const VALID_WINDOWS = ['4am', '7am', '8:30am', 'friday-pm'];
-const BASE_URL = process.env.VITE_EXTERNAL_SITE_URL || 'https://agirlandyourdog.com';
 
-// ---------------------------------------------------------------------------
-// Live schedule refresh
-// ---------------------------------------------------------------------------
-
-/**
- * Refresh today's daytime schedule data from the external site before building
- * the image. This ensures the 7am and 8:30am sends reflect actual changes made
- * after the midnight cron ran, making the hash-change gate meaningful.
- *
- * Strategy: mirrors the fetch + parse + upsert pattern from cron-schedule.js
- * lines 216–274, but scoped to just the current day and with no side effects
- * on boarding sync state.
- *
- * Error-handling: ALL errors are caught internally — this is a best-effort
- * pre-flight. A missing session, failed fetch, or upsert error logs a warning
- * and returns { refreshed: false } so the caller continues with stale DB data.
- * The send must never be blocked by a refresh failure.
- *
- * @param {import('@supabase/supabase-js').SupabaseClient} supabase
- * @param {Date} date - Local Date for the day being notified (usually today)
- * @returns {Promise<{ refreshed: boolean, rowCount: number, warning: string|null }>}
- */
-async function refreshDaytimeSchedule(supabase, date) {
-  // Outer try/catch ensures this function NEVER throws — every exit path returns
-  // { refreshed: boolean, rowCount: number, warning: string|null }.
-  // Docstring contract: "non-fatal pre-flight."
-  try {
-    // ensureSession: returns cached session or re-authenticates if expired/missing.
-    // Throws only if credentials are missing or auth fails — caught by outer catch.
-    let cookies;
-    try {
-      cookies = await ensureSession(supabase);
-    } catch (sessionErr) {
-      console.warn(`[Notify/Refresh] Could not obtain session: ${sessionErr.message} — skipping live refresh, using stale DB data`);
-      return { refreshed: false, rowCount: 0, warning: `Session unavailable: ${sessionErr.message}` };
-    }
-
-    // Inject session cookies so authenticatedFetch uses them.
-    setSession(cookies);
-
-    // Build the week-page URL for today. Month and day are NOT zero-padded —
-    // the external site uses bare numbers in its URL (e.g. /schedule/days-7/2026/3/6).
-    const y = date.getFullYear();
-    const m = date.getMonth() + 1; // 0-indexed → 1-indexed
-    const d = date.getDate();
-    const url = `${BASE_URL}/schedule/days-7/${y}/${m}/${d}`;
-    console.log(`[Notify/Refresh] Fetching schedule for ${y}-${String(m).padStart(2,'0')}-${String(d).padStart(2,'0')} from ${url}`);
-
-    let html;
-    try {
-      const response = await authenticatedFetch(url);
-      html = await response.text();
-    } catch (err) {
-      // Decision: SESSION_EXPIRED means the cached session was rejected by the server.
-      // Clear it so cron-auth re-authenticates on its next run rather than leaving a
-      // poisoned session in the cache that would cause the same failure at 7am and 8:30am.
-      if (err.message === 'SESSION_EXPIRED') {
-        console.warn('[Notify/Refresh] Session expired — clearing cached session so cron-auth re-authenticates');
-        await clearSession(supabase).catch(e =>
-          console.warn(`[Notify/Refresh] clearSession also failed: ${e.message}`)
-        );
-        return { refreshed: false, rowCount: 0, warning: 'Session expired — cron-auth will re-authenticate at midnight' };
-      }
-      console.warn(`[Notify/Refresh] Fetch failed (${err.message}) — continuing with stale DB data`);
-      return { refreshed: false, rowCount: 0, warning: `Schedule fetch failed: ${err.message}` };
-    }
-
-    console.log(`[Notify/Refresh] Fetched HTML — ${html.length} bytes`);
-
-    // Parse all daytime events (DC, PG, Boarding) from the schedule HTML.
-    const rows = parseDaytimeSchedulePage(html);
-    console.log(`[Notify/Refresh] Parsed ${rows.length} daytime events`);
-
-    // Surface zero-parse as a warning — could be access-denied redirect (large HTML)
-    // or empty/malformed response (small HTML). Either way the DB won't be updated.
-    let parseWarning = null;
-    if (rows.length === 0) {
-      const sizeNote = html.length > 10000 ? 'possible access-denied redirect' : 'small/empty response';
-      console.warn(`[Notify/Refresh] 0 events parsed from ${html.length}-byte response — ${sizeNote}`);
-      if (html.length > 10000) {
-        console.warn(`[Notify/Refresh] HTML preview: ${html.slice(0, 150).replace(/\s+/g, ' ')}`);
-      }
-      parseWarning = `Schedule fetched (${html.length} bytes) but 0 daytime events parsed — ${sizeNote}`;
-    }
-
-    // Upsert to DB. Non-fatal: upsertDaytimeAppointments does not throw on DB
-    // errors — it returns { upserted, errors } — so we log and carry on.
-    const { upserted, errors } = await upsertDaytimeAppointments(supabase, rows);
-    if (errors > 0) {
-      console.warn(`[Notify/Refresh] Upsert completed with ${errors} error(s) — ${upserted} rows written`);
-    } else {
-      console.log(`[Notify/Refresh] Upserted ${upserted} rows`);
-    }
-
-    return { refreshed: true, rowCount: upserted, warning: parseWarning };
-
-  } catch (err) {
-    // Catch-all: any unexpected error (getSession DB failure, parse crash, etc.)
-    // must not propagate — the send must not be blocked by a refresh failure.
-    console.warn(`[Notify/Refresh] Unexpected error: ${err.message} — continuing with stale DB data`);
-    return { refreshed: false, rowCount: 0, warning: `Unexpected refresh error: ${err.message}` };
-  }
-}
+// refreshDaytimeSchedule is imported from src/lib/notifyHelpers.js (extracted for testability).
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -186,24 +81,13 @@ async function sendRefreshAlert(supabase, warning, dateStr, notifyWindow) {
     console.warn(`[Notify/RefreshAlert] Could not read dedup state: ${err.message} — sending alert`);
   }
 
-  const from = process.env.TWILIO_FROM_NUMBER;
   const recipients = getRecipients();
-  if (!from || recipients.length === 0) return;
-
-  let client;
-  try {
-    client = createTwilioClient();
-  } catch (err) {
-    console.warn(`[Notify/RefreshAlert] Cannot create Twilio client: ${err.message}`);
-    return;
-  }
+  if (recipients.length === 0) return;
 
   const body = `⚠️ Notify refresh issue (${dateStr}, ${notifyWindow})\n${warning}`;
-  for (const to of recipients) {
-    await client.messages
-      .create({ from: `whatsapp:${from}`, to: `whatsapp:${to}`, body })
-      .catch(err => console.warn(`[Notify/RefreshAlert] Send failed to ***${to.slice(-4)}: ${err.message}`));
-  }
+  await sendTextMessage(body, recipients).catch(err =>
+    console.warn(`[Notify/RefreshAlert] sendTextMessage failed: ${err.message}`)
+  );
 
   // Record that we sent the alert for this date (non-fatal)
   await writeCronHealth(supabase, 'notify-refresh-alert', 'success', {
@@ -311,16 +195,10 @@ export default async function handler(req, res) {
         console.warn('[Notify] NOTIFY_RECIPIENTS not configured — send skipped');
         return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_recipients', window });
       }
-      const fromNumber = process.env.TWILIO_FROM_NUMBER;
-      if (!fromNumber) {
-        console.warn('[Notify] TWILIO_FROM_NUMBER not configured — send skipped');
-        return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_from_number', window });
-      }
 
       const supabase = getSupabase();
-      const twilioClient = createTwilioClient();
       console.log(`[Notify] Sending weekend roster to ${recipients.length} recipient(s)`);
-      const sendResults = await sendRosterImage(twilioClient, imageUrl, recipients, fromNumber);
+      const sendResults = await sendRosterImage(imageUrl, recipients);
       await writeCronHealth(supabase, 'notify-friday-pm', 'success', {
         sentAt: new Date().toISOString(),
         recipients: sendResults.map(r => r.to),
@@ -434,24 +312,16 @@ export default async function handler(req, res) {
     const imageUrl = `${protocol}://${host}/api/roster-image?date=${dateStr}&token=${expectedToken}`;
     console.log(`[Notify] Image URL: ${protocol}://${host}/api/roster-image?date=${dateStr}&token=***`);
 
-    // --- Get recipients and Twilio client ---
+    // --- Get recipients ---
     const recipients = getRecipients();
     if (recipients.length === 0) {
       console.warn('[Notify] NOTIFY_RECIPIENTS not configured — send skipped');
       return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_recipients' });
     }
 
-    const fromNumber = process.env.TWILIO_FROM_NUMBER;
-    if (!fromNumber) {
-      console.warn('[Notify] TWILIO_FROM_NUMBER not configured — send skipped');
-      return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_from_number' });
-    }
-
-    const twilioClient = createTwilioClient();
-
     // --- Send ---
     console.log(`[Notify] Sending to ${recipients.length} recipient(s)`);
-    const sendResults = await sendRosterImage(twilioClient, imageUrl, recipients, fromNumber);
+    const sendResults = await sendRosterImage(imageUrl, recipients);
 
     // --- Persist state (non-fatal) ---
     await persistSentState(supabase, currentHash, dateStr, window, sendResults);

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,4 +1,4 @@
-# Dog Boarding App — Session Handoff (v4.4.3 live, v5.0 next)
+# Dog Boarding App — Session Handoff (v5.0 in progress)
 **Last updated:** March 20, 2026
 
 ---
@@ -6,16 +6,25 @@
 ## Current State
 
 - **v4.4.3 LIVE** at [qboarding.vercel.app](https://qboarding.vercel.app) — tagged, latest release
-- **775 tests, 47 files, 0 failures**
-- **Main branch clean** — latest merged: #89
-- **Integration check Step 0 LIVE** — sync-before-compare verified 3/20: drained 15 queue items, PASS ✅
-- **`cron_health_log` verified** — table live, first row written (manual trigger March 19)
+- **799 tests, 49 files, 0 failures**
+- **v5.0 PR open** — M0, M1-1, M1-2, M2 all implemented (see PR for details)
+
+### v5.0 milestones in this PR
+
+- **M0 DONE** — `notifyWhatsApp.js` rewritten from Twilio to Meta Cloud API (`sendRosterImage`, `sendTextMessage`). `notify.js` updated accordingly. **Kate still needs to:** set up Meta app + register phone number + add `META_PHONE_NUMBER_ID` + `META_WHATSAPP_TOKEN` to GH secrets + Vercel env.
+- **M1-1 DONE** — Cron failure alerting: `'started'` status added to `cron_health` (migration 022), each cron (auth/schedule/detail) writes 'started' at top of run, `scripts/cron-health-check.js` + `.github/workflows/cron-health-check.yml` run at 00:30 UTC.
+- **M1-2 DONE** — `refreshDaytimeSchedule` extracted to `src/lib/notifyHelpers.js` (testable); 14 new tests covering all 7 exit paths + new notifyWhatsApp tests = 24 new tests total.
+- **M2 DONE** — Gmail monitor implemented: `scripts/gmail-monitor.js` + `.github/workflows/gmail-monitor.yml` (hourly at :15). **Kate still needs to:** create Google Cloud project, enable Gmail API, create OAuth2 creds, run one-time auth script → GMAIL_REFRESH_TOKEN, add `GMAIL_CLIENT_ID` + `GMAIL_CLIENT_SECRET` + `GMAIL_REFRESH_TOKEN` to GH secrets.
 
 ---
 
 ## IMMEDIATE NEXT (next session)
 
-1. **Start v5.0** — see `docs/SPRINT_PLAN.md`. First ticket: Gmail monitoring agent
+1. **Merge v5.0 PR** — after CI passes
+2. **Kate actions for M0**: Create Meta app, register phone number, get `META_PHONE_NUMBER_ID` + `META_WHATSAPP_TOKEN`
+3. **Kate actions for M2**: Google Cloud project + Gmail API + OAuth2 refresh token
+4. **Tag v5.0.0** GitHub release after merging
+5. **Deploy migration 022 + 023** via Supabase dashboard (ALTER TABLE + CREATE TABLE)
 
 ---
 
@@ -45,9 +54,29 @@ GitHub Actions (3×/day + on-demand: 1am/9am/5pm PDT)
 ```
 GitHub Actions (4 workflows: M-F 4am/7am/8:30am + Fri 3pm PDT)
   → GET /api/notify?window=4am|7am|830am|friday-pm
-  → refreshDaytimeSchedule → getPictureOfDay → computeWorkerDiff
-  → /api/roster-image → PNG → Twilio WhatsApp → NOTIFY_RECIPIENTS
+  → refreshDaytimeSchedule (src/lib/notifyHelpers.js) → getPictureOfDay → computeWorkerDiff
+  → /api/roster-image → PNG → Meta Cloud API (not Twilio) → NOTIFY_RECIPIENTS
   → hash stored in cron_health (7am/8:30am skip if no change; friday-pm always sends)
+```
+
+### Cron health check flow (M1-1, new)
+```
+GitHub Actions (daily 00:30 UTC)
+  → scripts/cron-health-check.js
+  → Supabase: check cron_health for auth/schedule/detail
+  → Alert if: any cron didn't run tonight, or 2+ consecutive failures
+  → Twilio WhatsApp → INTEGRATION_CHECK_RECIPIENTS
+```
+
+### Gmail monitor flow (M2, new)
+```
+GitHub Actions (hourly at :15)
+  → scripts/gmail-monitor.js
+  → OAuth2 refresh → Gmail REST API (unread from known senders)
+  → Subject-pattern filter (GitHub "run failed", Vercel "Failed", any Supabase)
+  → Supabase gmail_processed_emails dedup check
+  → Twilio WhatsApp alert → INTEGRATION_CHECK_RECIPIENTS
+  → Mark processed in Supabase
 ```
 
 ### Key files
@@ -60,7 +89,10 @@ GitHub Actions (4 workflows: M-F 4am/7am/8:30am + Fri 3pm PDT)
 | `src/lib/pictureOfDay.js` | getPictureOfDay, computeWorkerDiff, hashPicture |
 | `api/roster-image.js` | Token-gated PNG endpoint |
 | `api/notify.js` | Notify orchestrator (4am/7am/830am/friday-pm windows) |
-| `src/lib/notifyWhatsApp.js` | Twilio wrapper |
+| `src/lib/notifyWhatsApp.js` | Meta Cloud API wrapper (`sendRosterImage`, `sendTextMessage`) |
+| `src/lib/notifyHelpers.js` | `refreshDaytimeSchedule` (extracted from notify.js for testability) |
+| `scripts/cron-health-check.js` | Midnight cron health checker (GH Actions 00:30 UTC) |
+| `scripts/gmail-monitor.js` | Gmail infrastructure alert monitor (GH Actions hourly) |
 | `src/lib/scraper/sync.js` | runSync, 6-layer filter |
 | `src/lib/scraper/extraction.js` | parseAppointmentPage + booking_status |
 
@@ -79,6 +111,11 @@ GitHub Actions (4 workflows: M-F 4am/7am/8:30am + Fri 3pm PDT)
 | `INTEGRATION_CHECK_RECIPIENTS` | ✅ Set (Kate's number only) |
 | `APP_URL` | ✅ Set (not used in integration-check workflow) |
 | `VITE_SYNC_PROXY_TOKEN` | ✅ Set (not used in integration-check workflow) |
+| `META_PHONE_NUMBER_ID` | ⏳ Pending Kate — from Meta app dashboard |
+| `META_WHATSAPP_TOKEN` | ⏳ Pending Kate — system user access token from Meta app |
+| `GMAIL_CLIENT_ID` | ⏳ Pending Kate — from Google Cloud OAuth2 credentials |
+| `GMAIL_CLIENT_SECRET` | ⏳ Pending Kate — from Google Cloud OAuth2 credentials |
+| `GMAIL_REFRESH_TOKEN` | ⏳ Pending Kate — from one-time local auth flow |
 
 ### Workers
 | Name | External UID |

--- a/scripts/cron-health-check.js
+++ b/scripts/cron-health-check.js
@@ -1,0 +1,267 @@
+/* global process */
+/**
+ * Cron health check — verifies that each midnight Vercel cron ran successfully.
+ *
+ * Runs at 00:30 UTC (30 min after the midnight crons finish). Checks:
+ *
+ *   1. DID IT RUN?
+ *      For each cron (auth, schedule, detail): if cron_health.last_ran_at is
+ *      before midnight UTC today, the cron never ran tonight → alert.
+ *
+ *   2. DID IT SUCCEED?
+ *      If cron_health.status = 'failure', check cron_health_log for the last
+ *      2 entries. If both are failures → alert (consecutive = real problem).
+ *      A single failure in a sea of successes is likely transient noise.
+ *
+ * Sends alerts to INTEGRATION_CHECK_RECIPIENTS via Twilio (same as the
+ * integration-check.js path — Kate only, not the roster recipients).
+ *
+ * Exit codes: 0 on success or alerts-sent (job succeeded), 1 on startup crash.
+ *
+ * Required env vars (GitHub Actions Repository secrets):
+ *   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ *   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
+ *   INTEGRATION_CHECK_RECIPIENTS
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import twilio from 'twilio';
+
+// The three midnight Vercel crons we monitor.
+const MONITORED_CRONS = ['auth', 'schedule', 'detail'];
+
+// ---------------------------------------------------------------------------
+// Client factories
+// ---------------------------------------------------------------------------
+
+function getSupabase() {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  return createClient(url, key);
+}
+
+function getTwilioClient() {
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  if (!sid || !token) throw new Error('Missing Twilio env vars');
+  return twilio(sid, token);
+}
+
+function getRecipients() {
+  return (process.env.INTEGRATION_CHECK_RECIPIENTS || '').split(',').map(n => n.trim()).filter(Boolean);
+}
+
+function maskNumber(n) {
+  const d = n.replace(/\D/g, '');
+  return `***-***-${d.slice(-4)}`;
+}
+
+// ---------------------------------------------------------------------------
+// DB queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the latest cron_health row for each monitored cron.
+ * Returns a Map<cronName, { last_ran_at, status }>.
+ */
+async function loadCronHealth(supabase) {
+  console.log('[CronHealthCheck] Loading cron_health for monitored crons...');
+
+  const { data, error } = await supabase
+    .from('cron_health')
+    .select('cron_name, last_ran_at, status')
+    .in('cron_name', MONITORED_CRONS);
+
+  if (error) throw error;
+
+  const map = new Map();
+  for (const row of (data || [])) {
+    map.set(row.cron_name, { last_ran_at: row.last_ran_at, status: row.status });
+  }
+
+  console.log('[CronHealthCheck] Loaded %d cron_health row(s)', map.size);
+  return map;
+}
+
+/**
+ * For a given cron, return the last 2 log entries (newest first).
+ * Used to distinguish transient vs. consecutive failures.
+ */
+async function loadRecentLog(supabase, cronName) {
+  const { data, error } = await supabase
+    .from('cron_health_log')
+    .select('status, ran_at')
+    .eq('cron_name', cronName)
+    .order('ran_at', { ascending: false })
+    .limit(2);
+
+  if (error) throw error;
+  return data || [];
+}
+
+// ---------------------------------------------------------------------------
+// Check logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Check 1: Did the cron run since midnight UTC today?
+ * The checker runs at 00:30 UTC. Any cron with last_ran_at < midnight today
+ * has not run tonight.
+ *
+ * @param {string} cronName
+ * @param {{ last_ran_at: string, status: string }|undefined} healthRow
+ * @param {Date} midnightUtc - Start of today in UTC
+ * @returns {string|null} - Alert message or null if ok
+ */
+function checkDidRun(cronName, healthRow, midnightUtc) {
+  if (!healthRow) {
+    console.log('[CronHealthCheck] ⚠️  cron-%s: no health row in DB — never ran?', cronName);
+    return `cron-${cronName}: no health record found — may have never run`;
+  }
+
+  const lastRan = new Date(healthRow.last_ran_at);
+  if (lastRan < midnightUtc) {
+    console.log(
+      '[CronHealthCheck] ⚠️  cron-%s: last_ran_at=%s is before midnight UTC (%s) — did not run tonight',
+      cronName,
+      healthRow.last_ran_at,
+      midnightUtc.toISOString(),
+    );
+    return `cron-${cronName}: did not run tonight (last ran ${healthRow.last_ran_at})`;
+  }
+
+  console.log('[CronHealthCheck] ✅ cron-%s: ran at %s (status: %s)', cronName, healthRow.last_ran_at, healthRow.status);
+  return null;
+}
+
+/**
+ * Check 2: If the cron's current status is 'failure', are the last 2 log
+ * entries also failures? If yes → consecutive failures → alert.
+ *
+ * Single failures can be transient (Supabase blip, deploy race condition).
+ * Two in a row signals a real issue that needs attention.
+ *
+ * @param {string} cronName
+ * @param {{ last_ran_at: string, status: string }|undefined} healthRow
+ * @param {Array<{ status: string, ran_at: string }>} recentLog
+ * @returns {string|null}
+ */
+function checkConsecutiveFailures(cronName, healthRow, recentLog) {
+  if (!healthRow || healthRow.status !== 'failure') return null;
+
+  // cron_health shows 'failure'. Check the last 2 log entries.
+  const failures = recentLog.filter(r => r.status === 'failure');
+  const consecutiveFails = failures.length >= 2;
+
+  if (consecutiveFails) {
+    console.log('[CronHealthCheck] ⚠️  cron-%s: %d consecutive failure(s) in log', cronName, failures.length);
+    return `cron-${cronName}: ${failures.length} consecutive failure(s) — last ran ${healthRow.last_ran_at}`;
+  }
+
+  // Single failure — transient, don't alert
+  console.log('[CronHealthCheck] cron-%s: single failure (transient) — not alerting', cronName);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// WhatsApp
+// ---------------------------------------------------------------------------
+
+async function sendWhatsApp(twilioClient, message) {
+  const recipients = getRecipients();
+  const from = process.env.TWILIO_FROM_NUMBER;
+
+  if (!from) {
+    console.error('[CronHealthCheck] Missing TWILIO_FROM_NUMBER — cannot send WhatsApp');
+    return;
+  }
+  if (recipients.length === 0) {
+    console.log('[CronHealthCheck] No INTEGRATION_CHECK_RECIPIENTS — skipping WhatsApp send');
+    return;
+  }
+
+  console.log('[CronHealthCheck] Sending WhatsApp to %d recipient(s)...', recipients.length);
+  for (const to of recipients) {
+    try {
+      const msg = await twilioClient.messages.create({
+        from: `whatsapp:${from}`,
+        to: `whatsapp:${to}`,
+        body: message,
+      });
+      console.log('[CronHealthCheck] Sent to %s — SID: %s', maskNumber(to), msg.sid);
+    } catch (err) {
+      console.error('[CronHealthCheck] Twilio error for %s — code %s: %s', maskNumber(to), err.code, err.message);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log('[CronHealthCheck] === Cron health check starting ===');
+
+  // Midnight UTC today = start of the window the midnight crons should have run in
+  const now = new Date();
+  const midnightUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  console.log('[CronHealthCheck] Checking for runs since %s', midnightUtc.toISOString());
+
+  const todayStr = midnightUtc.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric', timeZone: 'UTC' });
+
+  const twilioClient = getTwilioClient();
+  const supabase = getSupabase();
+
+  const healthMap = await loadCronHealth(supabase);
+
+  const issues = [];
+
+  for (const cronName of MONITORED_CRONS) {
+    const healthRow = healthMap.get(cronName);
+
+    // Check 1: did it run?
+    const didNotRunAlert = checkDidRun(cronName, healthRow, midnightUtc);
+    if (didNotRunAlert) {
+      issues.push(didNotRunAlert);
+      // If it didn't run, no point checking consecutive failures
+      continue;
+    }
+
+    // Check 2: consecutive failures?
+    let recentLog = [];
+    try {
+      recentLog = await loadRecentLog(supabase, cronName);
+    } catch (err) {
+      console.error('[CronHealthCheck] Could not load log for cron-%s: %s', cronName, err.message);
+    }
+
+    const failureAlert = checkConsecutiveFailures(cronName, healthRow, recentLog);
+    if (failureAlert) {
+      issues.push(failureAlert);
+    }
+  }
+
+  const passed = issues.length === 0;
+  console.log('[CronHealthCheck] Result: %s (%d issue(s))', passed ? 'PASS ✅' : 'FAIL ⚠️', issues.length);
+
+  if (!passed) {
+    const lines = [
+      `⚠️ Cron health check (${todayStr})`,
+      ...issues.map(i => `• ${i}`),
+    ];
+    const message = lines.join('\n');
+    console.log('[CronHealthCheck] Sending alert:\n%s', message);
+    await sendWhatsApp(twilioClient, message);
+  } else {
+    console.log('[CronHealthCheck] All crons healthy — no alert needed');
+  }
+
+  console.log('[CronHealthCheck] === Done ===');
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('[CronHealthCheck] Unhandled error:', err.message, err.stack);
+  process.exit(1);
+});

--- a/scripts/gmail-monitor.js
+++ b/scripts/gmail-monitor.js
@@ -1,0 +1,452 @@
+/* global process */
+/**
+ * Gmail monitor — watches kcoffie@gmail.com for infrastructure failure emails.
+ *
+ * Runs hourly via GitHub Actions. For each unread email from a known sender
+ * that matches a subject pattern:
+ *   1. Checks gmail_processed_emails to skip already-processed emails
+ *   2. Sends a WhatsApp alert to INTEGRATION_CHECK_RECIPIENTS via Twilio
+ *   3. Records the email in gmail_processed_emails to prevent duplicates
+ *
+ * Authentication: uses OAuth2 with a long-lived refresh token (GMAIL_REFRESH_TOKEN).
+ * The refresh token is exchanged for a short-lived access token on each run.
+ * No googleapis SDK — raw fetch to the Gmail REST API.
+ *
+ * Known senders and subject filters:
+ *   - notifications@github.com    + subject matches "run failed" / "jobs failed"
+ *   - notifications@vercel.com    + subject matches "Failed"
+ *   - *@supabase.com (domain)     + any subject
+ *
+ * Required env vars (GitHub Actions Repository secrets):
+ *   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ *   GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN
+ *   TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER
+ *   INTEGRATION_CHECK_RECIPIENTS
+ *
+ * Optional:
+ *   ANTHROPIC_API_KEY — if set (and has credits), Claude summarizes the email body.
+ *                       Falls back to subject line if not set or API fails.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import twilio from 'twilio';
+
+// ---------------------------------------------------------------------------
+// Known sender configuration
+// ---------------------------------------------------------------------------
+
+const KNOWN_SENDERS = [
+  {
+    from: 'notifications@github.com',
+    name: 'GitHub Actions',
+    subjectPatterns: [
+      /run failed/i,
+      /some jobs were not successful/i,
+      /all jobs have failed/i,
+    ],
+  },
+  {
+    from: 'notifications@vercel.com',
+    name: 'Vercel',
+    subjectPatterns: [/failed/i],
+  },
+  {
+    fromDomain: 'supabase.com',
+    name: 'Supabase',
+    subjectPatterns: [/.*/], // any Supabase email is notable
+  },
+];
+
+// Gmail search query — cast a wide net by sender, then filter by subject in code.
+// Using 'is:unread' ensures we only process new emails each run.
+const GMAIL_QUERY = [
+  'from:(notifications@github.com OR notifications@vercel.com)',
+  'OR from:(@supabase.com)',
+  'is:unread',
+].join(' ');
+
+// ---------------------------------------------------------------------------
+// Client factories
+// ---------------------------------------------------------------------------
+
+function getSupabase() {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Missing VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  return createClient(url, key);
+}
+
+function getTwilioClient() {
+  const sid = process.env.TWILIO_ACCOUNT_SID;
+  const token = process.env.TWILIO_AUTH_TOKEN;
+  if (!sid || !token) throw new Error('Missing Twilio env vars');
+  return twilio(sid, token);
+}
+
+function getRecipients() {
+  return (process.env.INTEGRATION_CHECK_RECIPIENTS || '').split(',').map(n => n.trim()).filter(Boolean);
+}
+
+function maskNumber(n) {
+  const d = n.replace(/\D/g, '');
+  return `***-***-${d.slice(-4)}`;
+}
+
+// ---------------------------------------------------------------------------
+// OAuth2 — refresh token → access token
+// ---------------------------------------------------------------------------
+
+/**
+ * Exchange the long-lived refresh token for a short-lived Gmail access token.
+ * Called once per script run.
+ *
+ * @returns {Promise<string>} access token
+ */
+async function getAccessToken() {
+  const clientId = process.env.GMAIL_CLIENT_ID;
+  const clientSecret = process.env.GMAIL_CLIENT_SECRET;
+  const refreshToken = process.env.GMAIL_REFRESH_TOKEN;
+
+  if (!clientId || !clientSecret || !refreshToken) {
+    throw new Error('Missing Gmail OAuth2 env vars (GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN)');
+  }
+
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '(no body)');
+    throw new Error(`OAuth2 token refresh failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  if (!data.access_token) {
+    throw new Error('OAuth2 response missing access_token');
+  }
+
+  console.log('[GmailMonitor] OAuth2 token obtained (expires in %ds)', data.expires_in);
+  return data.access_token;
+}
+
+// ---------------------------------------------------------------------------
+// Gmail API
+// ---------------------------------------------------------------------------
+
+/**
+ * Search Gmail for unread emails from known infrastructure senders.
+ * Returns a list of message IDs.
+ *
+ * @param {string} accessToken
+ * @returns {Promise<string[]>} - List of message IDs
+ */
+async function searchGmail(accessToken) {
+  const params = new URLSearchParams({ q: GMAIL_QUERY, maxResults: '20' });
+  const url = `https://gmail.googleapis.com/gmail/v1/users/me/messages?${params}`;
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '(no body)');
+    throw new Error(`Gmail search failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  const ids = (data.messages || []).map(m => m.id);
+  console.log('[GmailMonitor] Gmail search returned %d message(s)', ids.length);
+  return ids;
+}
+
+/**
+ * Fetch the full message metadata (headers) for a given Gmail message ID.
+ * We only need From, Subject — no need to fetch the full body for filtering.
+ *
+ * @param {string} accessToken
+ * @param {string} messageId
+ * @returns {Promise<{ id: string, from: string, subject: string, snippet: string }>}
+ */
+async function fetchMessage(accessToken, messageId) {
+  const url = `https://gmail.googleapis.com/gmail/v1/users/me/messages/${messageId}?format=metadata&metadataHeaders=From&metadataHeaders=Subject`;
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '(no body)');
+    throw new Error(`Gmail fetch message ${messageId} failed (${response.status}): ${text}`);
+  }
+
+  const data = await response.json();
+  const headers = data.payload?.headers || [];
+  const from = headers.find(h => h.name === 'From')?.value || '';
+  const subject = headers.find(h => h.name === 'Subject')?.value || '(no subject)';
+
+  return {
+    id: messageId,
+    from,
+    subject,
+    snippet: data.snippet || '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sender matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if an email's from address matches a known sender config entry.
+ *
+ * @param {string} from - Raw From header value (may include display name)
+ * @param {{ from?: string, fromDomain?: string }} config
+ * @returns {boolean}
+ */
+function matchesSender(from, config) {
+  const fromLower = from.toLowerCase();
+  if (config.from) {
+    return fromLower.includes(config.from.toLowerCase());
+  }
+  if (config.fromDomain) {
+    return fromLower.includes(`@${config.fromDomain.toLowerCase()}`);
+  }
+  return false;
+}
+
+/**
+ * Find the matching sender config for an email, and check if its subject
+ * matches any of the configured subject patterns.
+ *
+ * @param {{ from: string, subject: string }} email
+ * @returns {{ senderConfig: object, matched: boolean }}
+ */
+function classifyEmail(email) {
+  for (const config of KNOWN_SENDERS) {
+    if (!matchesSender(email.from, config)) continue;
+
+    const subjectMatches = config.subjectPatterns.some(re => re.test(email.subject));
+    if (subjectMatches) {
+      return { senderConfig: config, matched: true };
+    }
+
+    // Sender matched but subject didn't — skip (e.g. GitHub PR comment)
+    console.log(
+      '[GmailMonitor] Skipping %s from %s — subject "%s" did not match filters',
+      email.id,
+      config.name,
+      email.subject,
+    );
+    return { senderConfig: config, matched: false };
+  }
+
+  // No sender config matched (shouldn't happen since Gmail query filters by sender)
+  return { senderConfig: null, matched: false };
+}
+
+// ---------------------------------------------------------------------------
+// Supabase dedup
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if an email has already been processed.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} emailId
+ * @returns {Promise<boolean>}
+ */
+async function isAlreadyProcessed(supabase, emailId) {
+  const { data, error } = await supabase
+    .from('gmail_processed_emails')
+    .select('email_id')
+    .eq('email_id', emailId)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('[GmailMonitor] Could not check processed status for %s: %s', emailId, error.message);
+    return false; // Fail open: process it anyway to avoid missing alerts
+  }
+
+  return !!data;
+}
+
+/**
+ * Mark an email as processed in Supabase.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ id: string, from: string, subject: string }} email
+ */
+async function markProcessed(supabase, email) {
+  const { error } = await supabase
+    .from('gmail_processed_emails')
+    .insert({
+      email_id: email.id,
+      sender: email.from,
+      subject: email.subject,
+      alert_sent: true,
+    });
+
+  if (error) {
+    console.warn('[GmailMonitor] Could not mark %s as processed: %s', email.id, error.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WhatsApp
+// ---------------------------------------------------------------------------
+
+async function sendWhatsApp(twilioClient, message) {
+  const recipients = getRecipients();
+  const from = process.env.TWILIO_FROM_NUMBER;
+
+  if (!from) {
+    console.error('[GmailMonitor] Missing TWILIO_FROM_NUMBER — cannot send WhatsApp');
+    return;
+  }
+  if (recipients.length === 0) {
+    console.log('[GmailMonitor] No INTEGRATION_CHECK_RECIPIENTS — skipping WhatsApp');
+    return;
+  }
+
+  for (const to of recipients) {
+    try {
+      const msg = await twilioClient.messages.create({
+        from: `whatsapp:${from}`,
+        to: `whatsapp:${to}`,
+        body: message,
+      });
+      console.log('[GmailMonitor] Sent to %s — SID: %s', maskNumber(to), msg.sid);
+    } catch (err) {
+      console.error('[GmailMonitor] Twilio error for %s — code %s: %s', maskNumber(to), err.code, err.message);
+    }
+  }
+}
+
+/**
+ * Build the WhatsApp alert message for a matched email.
+ * Optionally uses Claude for a 1-line summary if ANTHROPIC_API_KEY is set.
+ *
+ * Falls back to subject line if Claude is unavailable or has no credits.
+ *
+ * @param {{ id: string, from: string, subject: string, snippet: string }} email
+ * @param {{ name: string }} senderConfig
+ * @returns {Promise<string>}
+ */
+async function buildAlertMessage(email, senderConfig) {
+  let summary = email.subject;
+
+  // Optional: Claude summary (non-blocking)
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (anthropicKey && email.snippet) {
+    try {
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'x-api-key': anthropicKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'claude-haiku-4-5-20251001',
+          max_tokens: 100,
+          messages: [{
+            role: 'user',
+            content: `Summarize this infrastructure alert in one sentence (max 15 words):\nSubject: ${email.subject}\nSnippet: ${email.snippet}`,
+          }],
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        const claudeSummary = data?.content?.[0]?.text?.trim();
+        if (claudeSummary) summary = claudeSummary;
+      }
+    } catch (err) {
+      console.warn('[GmailMonitor] Claude summary failed (using subject): %s', err.message);
+    }
+  }
+
+  return [
+    `⚠️ Infrastructure Alert`,
+    `From: ${senderConfig.name}`,
+    `Subject: ${email.subject}`,
+    summary !== email.subject ? `Summary: ${summary}` : null,
+  ].filter(Boolean).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log('[GmailMonitor] === Gmail monitor starting ===');
+
+  const supabase = getSupabase();
+  const twilioClient = getTwilioClient();
+
+  // Step 1: Get Gmail access token
+  const accessToken = await getAccessToken();
+
+  // Step 2: Search for unread emails from known senders
+  const messageIds = await searchGmail(accessToken);
+
+  if (messageIds.length === 0) {
+    console.log('[GmailMonitor] No unread emails from known senders — done');
+    process.exit(0);
+  }
+
+  // Step 3: Process each message
+  let alertsSent = 0;
+  let skipped = 0;
+
+  for (const id of messageIds) {
+    let email;
+    try {
+      email = await fetchMessage(accessToken, id);
+    } catch (err) {
+      console.error('[GmailMonitor] Could not fetch message %s: %s', id, err.message);
+      continue;
+    }
+
+    console.log('[GmailMonitor] Processing: %s | From: %s | Subject: %s', id, email.from, email.subject);
+
+    // Classify — check sender + subject patterns
+    const { senderConfig, matched } = classifyEmail(email);
+    if (!matched) {
+      skipped++;
+      continue;
+    }
+
+    // Dedup check
+    const alreadyDone = await isAlreadyProcessed(supabase, id);
+    if (alreadyDone) {
+      console.log('[GmailMonitor] Already processed %s — skipping', id);
+      skipped++;
+      continue;
+    }
+
+    // Build and send alert
+    const message = await buildAlertMessage(email, senderConfig);
+    console.log('[GmailMonitor] Sending alert for %s:\n%s', id, message);
+    await sendWhatsApp(twilioClient, message);
+
+    // Mark processed
+    await markProcessed(supabase, email);
+    alertsSent++;
+  }
+
+  console.log('[GmailMonitor] === Done === (%d alert(s) sent, %d skipped)', alertsSent, skipped);
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('[GmailMonitor] Unhandled error:', err.message, err.stack);
+  process.exit(1);
+});

--- a/src/__tests__/notifyHelpers.test.js
+++ b/src/__tests__/notifyHelpers.test.js
@@ -1,0 +1,233 @@
+/**
+ * Tests for refreshDaytimeSchedule — all 7 exit paths.
+ * @requirements REQ-v5.0-M1-2
+ *
+ * The function's contract: NEVER throws. Every exit path returns
+ * { refreshed: boolean, rowCount: number, warning: string|null }.
+ *
+ * Exit paths:
+ *   1. ensureSession throws             → { refreshed: false, warning: 'Session unavailable: ...' }
+ *   2. authenticatedFetch throws SESSION_EXPIRED → clears session → { refreshed: false, warning: '...' }
+ *   3. authenticatedFetch throws (other) → { refreshed: false, warning: 'Schedule fetch failed: ...' }
+ *   4. rows.length === 0 + large HTML   → { refreshed: true, rowCount: 0, warning: '...access-denied...' }
+ *   5. rows.length === 0 + small HTML   → { refreshed: true, rowCount: 0, warning: '...small/empty...' }
+ *   6. Normal success (upsert errors)   → { refreshed: true, rowCount: N, warning: null }
+ *   7. Unexpected error (outer catch)   → { refreshed: false, warning: 'Unexpected refresh error: ...' }
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { refreshDaytimeSchedule } from '../lib/notifyHelpers.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../lib/scraper/sessionCache.js', () => ({
+  ensureSession: vi.fn(),
+  clearSession: vi.fn(),
+}));
+
+vi.mock('../lib/scraper/auth.js', () => ({
+  setSession: vi.fn(),
+  authenticatedFetch: vi.fn(),
+}));
+
+vi.mock('../lib/scraper/daytimeSchedule.js', () => ({
+  parseDaytimeSchedulePage: vi.fn(),
+  upsertDaytimeAppointments: vi.fn(),
+}));
+
+import { ensureSession, clearSession } from '../lib/scraper/sessionCache.js';
+import { setSession, authenticatedFetch } from '../lib/scraper/auth.js';
+import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from '../lib/scraper/daytimeSchedule.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_SUPABASE = {}; // refreshDaytimeSchedule passes it through; mocks handle it
+const TEST_DATE = new Date(2026, 2, 20); // March 20 2026 (local)
+
+const SMALL_HTML = '<html>tiny</html>';
+const LARGE_HTML = 'x'.repeat(11000); // > 10000 bytes → access-denied heuristic
+
+function makeHtmlResponse(body) {
+  return { text: () => Promise.resolve(body) };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: happy path
+  ensureSession.mockResolvedValue('session-cookies');
+  setSession.mockReturnValue(undefined);
+  authenticatedFetch.mockResolvedValue(makeHtmlResponse('<valid html>'));
+  parseDaytimeSchedulePage.mockReturnValue([{ id: 'appt1' }, { id: 'appt2' }]);
+  upsertDaytimeAppointments.mockResolvedValue({ upserted: 2, errors: 0 });
+});
+
+// ---------------------------------------------------------------------------
+// Exit path 1: ensureSession throws
+// ---------------------------------------------------------------------------
+
+describe('exit path 1: ensureSession throws', () => {
+  it('returns { refreshed: false } with session warning', async () => {
+    ensureSession.mockRejectedValue(new Error('No credentials'));
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(false);
+    expect(result.rowCount).toBe(0);
+    expect(result.warning).toMatch(/Session unavailable/);
+    expect(result.warning).toMatch(/No credentials/);
+    expect(authenticatedFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit path 2: authenticatedFetch throws SESSION_EXPIRED
+// ---------------------------------------------------------------------------
+
+describe('exit path 2: SESSION_EXPIRED', () => {
+  it('clears session and returns { refreshed: false } with expiry warning', async () => {
+    authenticatedFetch.mockRejectedValue(new Error('SESSION_EXPIRED'));
+    clearSession.mockResolvedValue(undefined);
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(false);
+    expect(result.rowCount).toBe(0);
+    expect(result.warning).toMatch(/Session expired/);
+    expect(clearSession).toHaveBeenCalledWith(MOCK_SUPABASE);
+    expect(parseDaytimeSchedulePage).not.toHaveBeenCalled();
+  });
+
+  it('returns { refreshed: false } even if clearSession also fails', async () => {
+    authenticatedFetch.mockRejectedValue(new Error('SESSION_EXPIRED'));
+    clearSession.mockRejectedValue(new Error('DB unavailable'));
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(false);
+    expect(result.warning).toMatch(/Session expired/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit path 3: authenticatedFetch throws (non-SESSION_EXPIRED)
+// ---------------------------------------------------------------------------
+
+describe('exit path 3: authenticatedFetch throws (other)', () => {
+  it('returns { refreshed: false } with fetch error warning', async () => {
+    authenticatedFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(false);
+    expect(result.rowCount).toBe(0);
+    expect(result.warning).toMatch(/Schedule fetch failed/);
+    expect(result.warning).toMatch(/ECONNREFUSED/);
+    expect(clearSession).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit path 4: 0 rows parsed + large HTML (access-denied heuristic)
+// ---------------------------------------------------------------------------
+
+describe('exit path 4: 0 rows + large HTML', () => {
+  it('returns { refreshed: true, rowCount: 0 } with access-denied warning', async () => {
+    authenticatedFetch.mockResolvedValue(makeHtmlResponse(LARGE_HTML));
+    parseDaytimeSchedulePage.mockReturnValue([]);
+    upsertDaytimeAppointments.mockResolvedValue({ upserted: 0, errors: 0 });
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(true);
+    expect(result.rowCount).toBe(0);
+    expect(result.warning).toMatch(/access-denied/);
+    expect(result.warning).toMatch(/0 daytime events/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit path 5: 0 rows parsed + small HTML
+// ---------------------------------------------------------------------------
+
+describe('exit path 5: 0 rows + small HTML', () => {
+  it('returns { refreshed: true, rowCount: 0 } with small/empty warning', async () => {
+    authenticatedFetch.mockResolvedValue(makeHtmlResponse(SMALL_HTML));
+    parseDaytimeSchedulePage.mockReturnValue([]);
+    upsertDaytimeAppointments.mockResolvedValue({ upserted: 0, errors: 0 });
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(true);
+    expect(result.rowCount).toBe(0);
+    expect(result.warning).toMatch(/small\/empty/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit path 6: normal success (upsert may have errors, warning is null)
+// ---------------------------------------------------------------------------
+
+describe('exit path 6: normal success', () => {
+  it('returns { refreshed: true, rowCount: N, warning: null } on clean upsert', async () => {
+    upsertDaytimeAppointments.mockResolvedValue({ upserted: 5, errors: 0 });
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(true);
+    expect(result.rowCount).toBe(5);
+    expect(result.warning).toBeNull();
+  });
+
+  it('still returns { refreshed: true } when upsert has partial errors', async () => {
+    upsertDaytimeAppointments.mockResolvedValue({ upserted: 3, errors: 2 });
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(true);
+    expect(result.rowCount).toBe(3);
+    expect(result.warning).toBeNull();
+  });
+
+  it('calls setSession with the cookies from ensureSession', async () => {
+    await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(setSession).toHaveBeenCalledWith('session-cookies');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exit path 7: unexpected error caught by outer try/catch
+// ---------------------------------------------------------------------------
+
+describe('exit path 7: unexpected outer error', () => {
+  it('returns { refreshed: false } with unexpected error warning when parseDaytimeSchedulePage throws', async () => {
+    parseDaytimeSchedulePage.mockImplementation(() => {
+      throw new Error('parse crash');
+    });
+    authenticatedFetch.mockResolvedValue(makeHtmlResponse('<valid html>'));
+
+    const result = await refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE);
+
+    expect(result.refreshed).toBe(false);
+    expect(result.rowCount).toBe(0);
+    expect(result.warning).toMatch(/Unexpected refresh error/);
+    expect(result.warning).toMatch(/parse crash/);
+  });
+
+  it('never throws — always returns an object', async () => {
+    upsertDaytimeAppointments.mockRejectedValue(new Error('DB exploded'));
+
+    await expect(refreshDaytimeSchedule(MOCK_SUPABASE, TEST_DATE)).resolves.toMatchObject({
+      refreshed: expect.any(Boolean),
+      rowCount: expect.any(Number),
+    });
+  });
+});

--- a/src/__tests__/notifyWhatsApp.test.js
+++ b/src/__tests__/notifyWhatsApp.test.js
@@ -1,0 +1,250 @@
+/**
+ * Tests for the Meta Cloud API WhatsApp wrapper.
+ * @requirements REQ-v5.0-M0
+ *
+ * All tests mock `fetch` (global) — no real network calls.
+ * Meta API creds are injected via process.env.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getRecipients, sendRosterImage, sendTextMessage } from '../lib/notifyWhatsApp.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a successful Meta API fetch response. */
+function metaOk(messageId = 'wamid.test123') {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ messages: [{ id: messageId }] }),
+  };
+}
+
+/** Build a failed Meta API fetch response. */
+function metaError(status = 400, body = '{"error":"Bad request"}') {
+  return {
+    ok: false,
+    status,
+    text: () => Promise.resolve(body),
+  };
+}
+
+/**
+ * Build a URL-aware fetch mock. The logger posts to /api/log — those calls
+ * return a trivial 200. Meta API calls (graph.facebook.com) return responses
+ * from the provided queue (in order). When the queue is exhausted, returns
+ * the default response.
+ *
+ * Returns { fetchMock, metaCalls } where metaCalls is a getter for the
+ * subset of fetch.mock.calls that targeted the Meta API.
+ */
+function makeFetchMock(metaResponses = []) {
+  const queue = [...metaResponses];
+  const defaultMeta = metaOk();
+
+  const fetchMock = vi.fn().mockImplementation((url) => {
+    if (typeof url === 'string' && url.includes('graph.facebook.com')) {
+      const next = queue.shift();
+      return Promise.resolve(next ?? defaultMeta);
+    }
+    // Logger calls (/api/log) — ignore silently
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+
+  return {
+    fetchMock,
+    /** Return only the Meta API calls (not logger /api/log calls). */
+    metaCalls: () => fetchMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.includes('graph.facebook.com')
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.META_PHONE_NUMBER_ID = 'phone-id-123';
+  process.env.META_WHATSAPP_TOKEN = 'token-abc';
+  process.env.NOTIFY_RECIPIENTS = '+18312477375,+14085551234';
+
+  // Default fetch mock: Meta calls succeed, logger calls (/api/log) are silenced.
+  const { fetchMock } = makeFetchMock();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  for (const key of ['META_PHONE_NUMBER_ID', 'META_WHATSAPP_TOKEN', 'NOTIFY_RECIPIENTS']) {
+    if (ORIG_ENV[key] === undefined) delete process.env[key];
+    else process.env[key] = ORIG_ENV[key];
+  }
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// getRecipients
+// ---------------------------------------------------------------------------
+
+describe('getRecipients', () => {
+  it('parses comma-separated E.164 numbers from NOTIFY_RECIPIENTS', () => {
+    process.env.NOTIFY_RECIPIENTS = '+18312477375,+14085551234';
+    expect(getRecipients()).toEqual(['+18312477375', '+14085551234']);
+  });
+
+  it('returns empty array when env var is unset', () => {
+    delete process.env.NOTIFY_RECIPIENTS;
+    expect(getRecipients()).toEqual([]);
+  });
+
+  it('trims whitespace and filters blank entries', () => {
+    process.env.NOTIFY_RECIPIENTS = '  +18312477375  ,  ,+14085551234  ';
+    expect(getRecipients()).toEqual(['+18312477375', '+14085551234']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendRosterImage
+// ---------------------------------------------------------------------------
+
+describe('sendRosterImage', () => {
+  it('calls Meta API with image type and correct payload', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock([metaOk('wamid.img001')]);
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendRosterImage(
+      'https://example.com/api/roster-image?token=secret',
+      ['+18312477375'],
+    );
+
+    expect(mc()).toHaveLength(1);
+    const [url, options] = mc()[0];
+    expect(url).toContain('phone-id-123/messages');
+    expect(url).toContain('graph.facebook.com');
+
+    const body = JSON.parse(options.body);
+    expect(body.messaging_product).toBe('whatsapp');
+    expect(body.to).toBe('+18312477375');
+    expect(body.type).toBe('image');
+    expect(body.image.link).toBe('https://example.com/api/roster-image?token=secret');
+
+    expect(options.headers.Authorization).toBe('Bearer token-abc');
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('sent');
+    expect(results[0].messageId).toBe('wamid.img001');
+  });
+
+  it('masks phone numbers in result to field', async () => {
+    const results = await sendRosterImage('https://example.com/img.png', ['+18312477375']);
+    expect(results[0].to).toBe('***-***-7375');
+  });
+
+  it('returns failed result when Meta API returns non-2xx', async () => {
+    const { fetchMock: fm } = makeFetchMock([metaError(400, '{"error":"invalid number"}')]);
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendRosterImage('https://example.com/img.png', ['+18312477375']);
+    expect(results[0].status).toBe('failed');
+    expect(results[0].error).toMatch(/Meta API error 400/);
+  });
+
+  it('sends to multiple recipients sequentially and collects results', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock([metaOk('wamid.001'), metaOk('wamid.002')]);
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendRosterImage('https://example.com/img.png', [
+      '+18312477375',
+      '+14085551234',
+    ]);
+
+    expect(mc()).toHaveLength(2);
+    expect(results).toHaveLength(2);
+    expect(results[0].status).toBe('sent');
+    expect(results[1].status).toBe('sent');
+  });
+
+  it('continues to next recipient if one fails', async () => {
+    const { fetchMock: fm } = makeFetchMock([metaError(400), metaOk('wamid.002')]);
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendRosterImage('https://example.com/img.png', [
+      '+18312477375',
+      '+14085551234',
+    ]);
+
+    expect(results[0].status).toBe('failed');
+    expect(results[1].status).toBe('sent');
+  });
+
+  it('returns failed results for all recipients when credentials missing', async () => {
+    delete process.env.META_PHONE_NUMBER_ID;
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock();
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendRosterImage('https://example.com/img.png', [
+      '+18312477375',
+      '+14085551234',
+    ]);
+
+    expect(mc()).toHaveLength(0);
+    expect(results).toHaveLength(2);
+    results.forEach(r => {
+      expect(r.status).toBe('failed');
+      expect(r.error).toMatch(/credentials not configured/i);
+    });
+  });
+
+  it('returns empty array when recipients list is empty', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock();
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendRosterImage('https://example.com/img.png', []);
+    expect(mc()).toHaveLength(0);
+    expect(results).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendTextMessage
+// ---------------------------------------------------------------------------
+
+describe('sendTextMessage', () => {
+  it('calls Meta API with text type and correct body', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock([metaOk('wamid.txt001')]);
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendTextMessage('⚠️ Alert message', ['+18312477375']);
+
+    expect(mc()).toHaveLength(1);
+    const body = JSON.parse(mc()[0][1].body);
+    expect(body.type).toBe('text');
+    expect(body.text.body).toBe('⚠️ Alert message');
+    expect(body.to).toBe('+18312477375');
+
+    expect(results[0].status).toBe('sent');
+    expect(results[0].messageId).toBe('wamid.txt001');
+  });
+
+  it('returns failed results when credentials missing', async () => {
+    delete process.env.META_WHATSAPP_TOKEN;
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock();
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendTextMessage('test', ['+18312477375']);
+    expect(mc()).toHaveLength(0);
+    expect(results[0].status).toBe('failed');
+  });
+
+  it('returns empty array when recipients list is empty', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock();
+    vi.stubGlobal('fetch', fm);
+
+    const results = await sendTextMessage('test', []);
+    expect(mc()).toHaveLength(0);
+    expect(results).toEqual([]);
+  });
+});

--- a/src/lib/notifyHelpers.js
+++ b/src/lib/notifyHelpers.js
@@ -1,0 +1,113 @@
+/* global process */
+/**
+ * Notify helper functions extracted for testability.
+ *
+ * `refreshDaytimeSchedule` was previously inlined in api/notify.js. It is
+ * extracted here so it can be unit-tested without standing up the HTTP handler.
+ *
+ * @requirements REQ-v5.0-M1-2
+ */
+
+import { ensureSession, clearSession } from './scraper/sessionCache.js';
+import { setSession, authenticatedFetch } from './scraper/auth.js';
+import { parseDaytimeSchedulePage, upsertDaytimeAppointments } from './scraper/daytimeSchedule.js';
+
+const BASE_URL = process.env.VITE_EXTERNAL_SITE_URL || 'https://agirlandyourdog.com';
+
+/**
+ * Refresh today's daytime schedule data from the external site before building
+ * the image. This ensures the 7am and 8:30am sends reflect actual changes made
+ * after the midnight cron ran, making the hash-change gate meaningful.
+ *
+ * Strategy: mirrors the fetch + parse + upsert pattern from cron-schedule.js
+ * scoped to just the current day with no side effects on boarding sync state.
+ *
+ * Error-handling: ALL errors are caught internally — this is a best-effort
+ * pre-flight. A missing session, failed fetch, or upsert error logs a warning
+ * and returns { refreshed: false } so the caller continues with stale DB data.
+ * The send must never be blocked by a refresh failure.
+ *
+ * Exit paths:
+ *   1. ensureSession throws             → { refreshed: false, warning: 'Session unavailable: ...' }
+ *   2. authenticatedFetch throws SESSION_EXPIRED → clears session → { refreshed: false, warning: '...' }
+ *   3. authenticatedFetch throws (other) → { refreshed: false, warning: 'Schedule fetch failed: ...' }
+ *   4. rows.length === 0 + large HTML   → { refreshed: true, rowCount: 0, warning: '...access-denied...' }
+ *   5. rows.length === 0 + small HTML   → { refreshed: true, rowCount: 0, warning: '...small/empty...' }
+ *   6. Upsert has errors               → { refreshed: true, rowCount: N, warning: null }
+ *   7. Unexpected error (outer catch)   → { refreshed: false, warning: 'Unexpected refresh error: ...' }
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Date} date - Local Date for the day being notified (usually today)
+ * @returns {Promise<{ refreshed: boolean, rowCount: number, warning: string|null }>}
+ */
+export async function refreshDaytimeSchedule(supabase, date) {
+  // Outer try/catch ensures this function NEVER throws — every exit path returns
+  // { refreshed: boolean, rowCount: number, warning: string|null }.
+  try {
+    // ensureSession: returns cached session or re-authenticates if expired/missing.
+    // Throws only if credentials are missing or auth fails — caught by outer catch.
+    let cookies;
+    try {
+      cookies = await ensureSession(supabase);
+    } catch (sessionErr) {
+      console.warn(`[Notify/Refresh] Could not obtain session: ${sessionErr.message} — skipping live refresh, using stale DB data`);
+      return { refreshed: false, rowCount: 0, warning: `Session unavailable: ${sessionErr.message}` };
+    }
+
+    // Inject session cookies so authenticatedFetch uses them.
+    setSession(cookies);
+
+    // Build the week-page URL for today. Month and day are NOT zero-padded —
+    // the external site uses bare numbers in its URL (e.g. /schedule/days-7/2026/3/6).
+    const y = date.getFullYear();
+    const m = date.getMonth() + 1; // 0-indexed → 1-indexed
+    const d = date.getDate();
+    const url = `${BASE_URL}/schedule/days-7/${y}/${m}/${d}`;
+    console.log(`[Notify/Refresh] Fetching schedule for ${y}-${String(m).padStart(2,'0')}-${String(d).padStart(2,'0')} from ${url}`);
+
+    let html;
+    try {
+      const response = await authenticatedFetch(url);
+      html = await response.text();
+    } catch (err) {
+      // SESSION_EXPIRED: clear the cached session so cron-auth re-authenticates.
+      if (err.message === 'SESSION_EXPIRED') {
+        console.warn('[Notify/Refresh] Session expired — clearing cached session so cron-auth re-authenticates');
+        await clearSession(supabase).catch(e =>
+          console.warn(`[Notify/Refresh] clearSession also failed: ${e.message}`)
+        );
+        return { refreshed: false, rowCount: 0, warning: 'Session expired — cron-auth will re-authenticate at midnight' };
+      }
+      console.warn(`[Notify/Refresh] Fetch failed (${err.message}) — continuing with stale DB data`);
+      return { refreshed: false, rowCount: 0, warning: `Schedule fetch failed: ${err.message}` };
+    }
+
+    console.log(`[Notify/Refresh] Fetched HTML — ${html.length} bytes`);
+
+    const rows = parseDaytimeSchedulePage(html);
+    console.log(`[Notify/Refresh] Parsed ${rows.length} daytime events`);
+
+    let parseWarning = null;
+    if (rows.length === 0) {
+      const sizeNote = html.length > 10000 ? 'possible access-denied redirect' : 'small/empty response';
+      console.warn(`[Notify/Refresh] 0 events parsed from ${html.length}-byte response — ${sizeNote}`);
+      if (html.length > 10000) {
+        console.warn(`[Notify/Refresh] HTML preview: ${html.slice(0, 150).replace(/\s+/g, ' ')}`);
+      }
+      parseWarning = `Schedule fetched (${html.length} bytes) but 0 daytime events parsed — ${sizeNote}`;
+    }
+
+    const { upserted, errors } = await upsertDaytimeAppointments(supabase, rows);
+    if (errors > 0) {
+      console.warn(`[Notify/Refresh] Upsert completed with ${errors} error(s) — ${upserted} rows written`);
+    } else {
+      console.log(`[Notify/Refresh] Upserted ${upserted} rows`);
+    }
+
+    return { refreshed: true, rowCount: upserted, warning: parseWarning };
+
+  } catch (err) {
+    console.warn(`[Notify/Refresh] Unexpected error: ${err.message} — continuing with stale DB data`);
+    return { refreshed: false, rowCount: 0, warning: `Unexpected refresh error: ${err.message}` };
+  }
+}

--- a/src/lib/notifyWhatsApp.js
+++ b/src/lib/notifyWhatsApp.js
@@ -1,26 +1,27 @@
 /**
- * WhatsApp notification wrapper — sends the daily roster image via Twilio.
+ * WhatsApp notification wrapper — sends messages via Meta Cloud API.
  *
- * Design: thin wrapper around the Twilio REST API. All Twilio-specific error
+ * Design: thin wrapper around the Meta Graph API. All Meta-specific error
  * handling is isolated here so callers (api/notify.js) work with a simple
- * { status, sid } contract. No business logic lives here.
+ * { status, messageId } contract. No business logic lives here.
  *
- * Twilio WhatsApp requires:
- *   from: "whatsapp:+14155238886"   (sandbox number or approved sender)
- *   to:   "whatsapp:+18312477375"
- *   mediaUrl: [publicly accessible image URL]
+ * Meta WhatsApp Cloud API requires:
+ *   META_PHONE_NUMBER_ID — the sender number ID from the Meta app dashboard
+ *   META_WHATSAPP_TOKEN  — permanent system user access token
  *
+ * Recipients: E.164 format without 'whatsapp:' prefix (Meta uses plain numbers).
  * Security: recipient numbers are masked to last 4 digits in all log output.
  *
- * @requirements REQ-v4.1
+ * @requirements REQ-v4.1, REQ-v5.0-M0
  */
 
-import twilio from 'twilio';
 import { createSyncLogger } from './scraper/logger.js';
 
 const logger = createSyncLogger('NotifyWA');
 const log = logger.log;
 const logWarn = logger.warn;
+
+const META_API_VERSION = 'v18.0';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -53,50 +54,75 @@ export function getRecipients() {
 }
 
 // ---------------------------------------------------------------------------
-// Twilio client factory
+// Meta Cloud API
 // ---------------------------------------------------------------------------
 
 /**
- * Create a Twilio REST client from environment variables.
+ * Read Meta credentials from environment.
+ * Returns null if either var is missing — callers handle the missing-config case.
  *
- * Error-handling: throws if required env vars are missing so the caller
- * can log a clear error and skip the send rather than passing undefined
- * credentials to Twilio (which would throw an opaque HTTP 401).
- *
- * @returns {import('twilio').Twilio}
+ * @returns {{ phoneNumberId: string, token: string }|null}
  */
-export function createTwilioClient() {
-  const sid = process.env.TWILIO_ACCOUNT_SID;
-  const token = process.env.TWILIO_AUTH_TOKEN;
-  if (!sid || !token) {
-    throw new Error('Twilio env vars not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)');
+function getMetaCredentials() {
+  const phoneNumberId = process.env.META_PHONE_NUMBER_ID;
+  const token = process.env.META_WHATSAPP_TOKEN;
+  if (!phoneNumberId || !token) return null;
+  return { phoneNumberId, token };
+}
+
+/**
+ * POST a single message to the Meta Cloud API.
+ *
+ * @param {string} phoneNumberId - Sender phone number ID
+ * @param {string} token         - System user access token
+ * @param {string} to            - Recipient E.164 number
+ * @param {object} messagePayload - { type, image|text } object
+ * @returns {Promise<{ messageId: string }>}
+ * @throws on non-2xx HTTP response
+ */
+async function metaApiSend(phoneNumberId, token, to, messagePayload) {
+  const url = `https://graph.facebook.com/${META_API_VERSION}/${phoneNumberId}/messages`;
+  const body = {
+    messaging_product: 'whatsapp',
+    to,
+    ...messagePayload,
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '(no body)');
+    throw new Error(`Meta API error ${response.status}: ${text}`);
   }
-  return twilio(sid, token);
+
+  const data = await response.json();
+  // Meta returns: { messages: [{ id: "wamid.xxx" }] }
+  return { messageId: data?.messages?.[0]?.id ?? 'unknown' };
 }
 
 // ---------------------------------------------------------------------------
-// Send function
+// Send functions
 // ---------------------------------------------------------------------------
 
 /**
- * Send the roster image to one or more WhatsApp numbers.
+ * Send the roster image to one or more WhatsApp numbers via Meta Cloud API.
  *
- * Iterates recipients sequentially (not parallel) to avoid Twilio rate limits.
- * Each recipient gets its own try/catch so a single bad number doesn't block
- * the rest of the list.
+ * Iterates recipients sequentially (not parallel) to stay within Meta's rate
+ * limits. Each recipient gets its own try/catch so a single bad number doesn't
+ * block the rest of the list.
  *
- * Decision logging at each step:
- *   - Entry: recipient count, masked numbers, image URL host
- *   - Per-recipient: masked number, Twilio SID on success, error code on failure
- *   - Exit: sent count, failed count
- *
- * @param {import('twilio').Twilio} client - Twilio client instance
- * @param {string} imageUrl               - Public URL to the roster PNG
- * @param {string[]} recipients           - E.164 phone numbers to send to
- * @param {string} fromNumber             - E.164 Twilio sender number
- * @returns {Promise<Array<{to, status, sid?, error?}>>}
+ * @param {string} imageUrl     - Publicly accessible URL to the roster PNG
+ * @param {string[]} recipients - E.164 phone numbers
+ * @returns {Promise<Array<{to, status, messageId?, error?}>>}
  */
-export async function sendRosterImage(client, imageUrl, recipients, fromNumber) {
+export async function sendRosterImage(imageUrl, recipients) {
   log(`sendRosterImage — ${recipients.length} recipients, imageUrl host: ${new URL(imageUrl).hostname}`);
 
   if (recipients.length === 0) {
@@ -104,37 +130,92 @@ export async function sendRosterImage(client, imageUrl, recipients, fromNumber) 
     return [];
   }
 
+  const creds = getMetaCredentials();
+  if (!creds) {
+    logWarn('Meta API credentials not configured (META_PHONE_NUMBER_ID, META_WHATSAPP_TOKEN)');
+    return recipients.map(to => ({
+      to: maskNumber(to),
+      status: 'failed',
+      error: 'Meta API credentials not configured',
+    }));
+  }
+
   const results = [];
 
   for (const to of recipients) {
     const masked = maskNumber(to);
-    log(`Sending to ${masked}...`);
+    log(`Sending image to ${masked}...`);
 
     try {
-      const message = await client.messages.create({
-        from: `whatsapp:${fromNumber}`,
-        to: `whatsapp:${to}`,
-        mediaUrl: [imageUrl],
-        // body is required by some WhatsApp clients even for media-only messages.
-        body: '',
+      const { messageId } = await metaApiSend(creds.phoneNumberId, creds.token, to, {
+        type: 'image',
+        image: { link: imageUrl },
       });
-
-      log(`Sent to ${masked} — SID: ${message.sid}, status: ${message.status}`);
-      results.push({ to: masked, status: 'sent', sid: message.sid });
-
+      log(`Sent to ${masked} — messageId: ${messageId}`);
+      results.push({ to: masked, status: 'sent', messageId });
     } catch (err) {
-      // Twilio errors have a `code` property (numeric error code) and `status` (HTTP).
-      // Log both for diagnosis. Common codes: 21608 (unverified number), 63016 (sandbox limit).
-      const code = err.code ?? 'unknown';
-      const httpStatus = err.status ?? 'unknown';
-      logWarn(`Failed to send to ${masked} — Twilio error ${code} (HTTP ${httpStatus}): ${err.message}`);
-      results.push({ to: masked, status: 'failed', error: err.message, twilioCode: code });
+      logWarn(`Failed to send to ${masked}: ${err.message}`);
+      results.push({ to: masked, status: 'failed', error: err.message });
     }
   }
 
   const sentCount = results.filter(r => r.status === 'sent').length;
   const failedCount = results.filter(r => r.status === 'failed').length;
   log(`sendRosterImage complete — ${sentCount} sent, ${failedCount} failed`);
+
+  return results;
+}
+
+/**
+ * Send a plain-text WhatsApp message to one or more numbers via Meta Cloud API.
+ *
+ * Used for operational alerts (refresh warnings, cron failure notices, etc.).
+ * Same sequential + isolated-error-handling pattern as sendRosterImage.
+ *
+ * @param {string} text         - Message body
+ * @param {string[]} recipients - E.164 phone numbers
+ * @returns {Promise<Array<{to, status, messageId?, error?}>>}
+ */
+export async function sendTextMessage(text, recipients) {
+  log(`sendTextMessage — ${recipients.length} recipients`);
+
+  if (recipients.length === 0) {
+    logWarn('No recipients configured — skipping send');
+    return [];
+  }
+
+  const creds = getMetaCredentials();
+  if (!creds) {
+    logWarn('Meta API credentials not configured (META_PHONE_NUMBER_ID, META_WHATSAPP_TOKEN)');
+    return recipients.map(to => ({
+      to: maskNumber(to),
+      status: 'failed',
+      error: 'Meta API credentials not configured',
+    }));
+  }
+
+  const results = [];
+
+  for (const to of recipients) {
+    const masked = maskNumber(to);
+    log(`Sending text to ${masked}...`);
+
+    try {
+      const { messageId } = await metaApiSend(creds.phoneNumberId, creds.token, to, {
+        type: 'text',
+        text: { body: text },
+      });
+      log(`Sent to ${masked} — messageId: ${messageId}`);
+      results.push({ to: masked, status: 'sent', messageId });
+    } catch (err) {
+      logWarn(`Failed to send to ${masked}: ${err.message}`);
+      results.push({ to: masked, status: 'failed', error: err.message });
+    }
+  }
+
+  const sentCount = results.filter(r => r.status === 'sent').length;
+  const failedCount = results.filter(r => r.status === 'failed').length;
+  log(`sendTextMessage complete — ${sentCount} sent, ${failedCount} failed`);
 
   return results;
 }

--- a/supabase/migrations/022_extend_cron_health_status.sql
+++ b/supabase/migrations/022_extend_cron_health_status.sql
@@ -1,0 +1,20 @@
+-- Migration 022: Extend cron_health status values
+--
+-- Adds 'started' to the CHECK constraint on cron_health.status.
+-- This enables each cron to write a 'started' row at the top of its run,
+-- before any real work. The cron-health-check script can then distinguish:
+--   - status='started' with an old last_ran_at → cron launched but hard-crashed
+--   - status='failure' → cron ran but returned an error
+--   - status='success' → cron completed normally
+--
+-- The cron_health_log table does not have a CHECK constraint on status,
+-- so no changes are needed there.
+--
+-- @requirements REQ-v5.0-M1-1
+
+ALTER TABLE cron_health
+  DROP CONSTRAINT IF EXISTS cron_health_status_check;
+
+ALTER TABLE cron_health
+  ADD CONSTRAINT cron_health_status_check
+  CHECK (status IN ('success', 'failure', 'started'));

--- a/supabase/migrations/023_add_gmail_processed_emails.sql
+++ b/supabase/migrations/023_add_gmail_processed_emails.sql
@@ -1,0 +1,39 @@
+-- Migration 023: Gmail processed emails tracking
+--
+-- Stores every email that the gmail-monitor script has processed, keyed by
+-- Gmail message ID. Prevents duplicate WhatsApp alerts if the monitor script
+-- runs again before Gmail marks the email as read (or if the script is
+-- triggered manually while the hourly cron is also running).
+--
+-- Retention: rows accumulate indefinitely; volume is very low (a few per month).
+-- No automated TTL needed for now.
+--
+-- @requirements REQ-v5.0-M2
+
+CREATE TABLE IF NOT EXISTS gmail_processed_emails (
+  email_id     TEXT        PRIMARY KEY,
+  sender       TEXT        NOT NULL,
+  subject      TEXT,
+  alert_sent   BOOLEAN     NOT NULL DEFAULT TRUE,
+  processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for looking up recent emails by sender (useful for debugging)
+CREATE INDEX IF NOT EXISTS gmail_processed_emails_sender_idx
+  ON gmail_processed_emails (sender, processed_at DESC);
+
+-- RLS: service role has full access (script uses service role key)
+ALTER TABLE gmail_processed_emails ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service role full access"
+  ON gmail_processed_emails
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "authenticated read"
+  ON gmail_processed_emails
+  FOR SELECT
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
## Summary

- **M0**: Rewrite `notifyWhatsApp.js` from Twilio SDK to Meta Cloud API. Update `api/notify.js` to remove all `TWILIO_FROM_NUMBER` / `createTwilioClient` references. New env vars needed: `META_PHONE_NUMBER_ID`, `META_WHATSAPP_TOKEN` (Kate action).
- **M1-1**: Cron failure alerting — migration 022 adds `started` to `cron_health.status` CHECK constraint; each midnight cron writes a `started` row at launch; new `scripts/cron-health-check.js` + workflow runs at 00:30 UTC and alerts via Twilio if any cron missed or has 2 consecutive failures.
- **M1-2**: Extract `refreshDaytimeSchedule` from `api/notify.js` to `src/lib/notifyHelpers.js` for testability. 24 new tests.
- **M2**: Gmail monitor — `scripts/gmail-monitor.js` + hourly workflow; OAuth2 refresh → Gmail API → subject-pattern filter → Supabase dedup → Twilio WhatsApp alert. Migration 023 adds `gmail_processed_emails` table. Kate actions needed before first run.

## Kate actions required

**M0 (before routing works end-to-end):**
1. Create Meta for Developers app → add WhatsApp product
2. Register a phone number (recommend buying a Twilio number ~$1/mo)
3. Add Kate + recipient as test recipients in Meta dashboard
4. Create system user → get permanent access token
5. Add `META_PHONE_NUMBER_ID` + `META_WHATSAPP_TOKEN` to GH secrets AND Vercel env

**M2 (before Gmail monitor activates):**
1. Create Google Cloud project + enable Gmail API
2. Create OAuth2 credentials (web app type)
3. Run one-time local auth script → capture `GMAIL_REFRESH_TOKEN`
4. Add `GMAIL_CLIENT_ID`, `GMAIL_CLIENT_SECRET`, `GMAIL_REFRESH_TOKEN` to GH secrets

**After merging:** run migration 022 + 023 via Supabase dashboard

## Test plan
- [x] 799 tests, 0 failures (`npm run test:run`)
- [x] Lint passes (husky pre-commit)
- [ ] After Meta credentials set: trigger `notify-4am` manually and verify WhatsApp delivery
- [ ] After Gmail credentials set: trigger `gmail-monitor` via workflow_dispatch
- [ ] `cron-health-check` can be triggered via workflow_dispatch to verify logic
