### PR TITLE
docs: session handoff + sprint plan update post-M3 evening (#97)

### DIFF
--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,5 +1,5 @@
 # Dog Boarding App — Session Handoff (v5.0 live)
-**Last updated:** March 20, 2026
+**Last updated:** March 20, 2026 (evening)
 
 ---
 
@@ -9,6 +9,7 @@
 - **835 tests, 51 files, 0 failures**
 - PR #91 merged — M0, M1-1, M1-2, M2 all shipped and verified live
 - PR #93 merged — M3-1/2/3 done (README overhaul, runbook, ADRs); test files committed; SPRINT_PLAN.md now in git
+- PR #95 merged — `docs/job_docs/gmail-monitor.md` added; README mermaid diagram fixed (`@` in node label)
 
 ### v5.0 milestones — all live ✅
 
@@ -22,6 +23,9 @@
 - **Second WhatsApp recipient** — Kate to provide second number → add to `NOTIFY_RECIPIENTS` secret (comma-separated E.164)
 - **Anthropic credits** — Step 3 of integration check (Claude vision name-check) still silently skipped
 
+### Known monitoring gap — WhatsApp delivery receipts
+Friday PM notify ran at 22:37 UTC (3:37 PM PDT) on March 20. Job returned HTTP 200, `sentCount:1`, and a real `wamid` from Meta — meaning Meta accepted the message. Kate did not receive it. The failure was at the Meta → phone delivery layer, which is invisible to the current monitoring stack. The cron health check only catches job-level failures (non-zero exit), not post-acceptance delivery failures. **To close this gap:** implement Meta Webhooks delivery receipt handling. Meta will POST to a webhook URL when a message is delivered or fails; the app could alert if a sent `wamid` doesn't receive a delivered status within N minutes.
+
 ---
 
 ## IMMEDIATE NEXT (next session)
@@ -34,6 +38,8 @@
 4. **M3-7** — Screen recording of WhatsApp roster image arriving on phone (most impactful portfolio artifact; embed in README)
 5. **M3-8** — App screenshots in README (boarding matrix, roster image — currently no visuals)
 6. **M3-9** — CHANGELOG.md documenting v1.0 → v5.0.0 release history
+
+**Potential new ticket — WhatsApp delivery receipts (Meta Webhooks):** Friday PM job ran and returned a valid wamid but message was not received. Monitoring gap: post-acceptance delivery failures are invisible. Fix requires Meta Webhooks integration.
 
 ---
 

--- a/docs/SPRINT_PLAN.md
+++ b/docs/SPRINT_PLAN.md
@@ -1,6 +1,6 @@
 # Q Boarding — Sprint Plan (v5.0)
 
-_Last updated: March 20, 2026 — M0/M1/M2/M3-1/2/3 all live_
+_Last updated: March 20, 2026 (evening) — M0/M1/M2/M3-1/2/3 all live; job docs complete_
 
 ---
 
@@ -149,6 +149,7 @@ All v4 work is done. See `docs/archive/SESSION_HANDOFF_v4.5_final.md` for full h
 | M3-7 | Screen recording of WhatsApp roster image arriving on phone — most impactful portfolio artifact; embed in README | — |
 | M3-8 | App screenshots in README — boarding matrix, roster image — currently no visuals | — |
 | M3-9 | CHANGELOG.md — document iterative release history from v1.0 → v5.0.0; shows production-minded development discipline | — |
+| M3-10 | WhatsApp delivery receipts (Meta Webhooks) — detect post-acceptance delivery failures; Friday PM wamid returned but message not received March 20 | — |
 
 ---
 


### PR DESCRIPTION
## Summary
- SESSION_HANDOFF: note PR #95 merged; document WhatsApp delivery receipt monitoring gap (Friday PM wamid returned, message not received — failure at Meta → phone layer, invisible to current stack); add M3-10 as potential new ticket
- SPRINT_PLAN: add M3-10 (Meta Webhooks delivery receipts), update timestamp

## Test plan
- [ ] CI passes
