### PR TITLE
docs: fix notify-jobs doc — Twilio refs stale since M0 Meta switch (#99)

### DIFF
--- a/docs/job_docs/notify-jobs.md
+++ b/docs/job_docs/notify-jobs.md
@@ -1,7 +1,7 @@
 # Notify Jobs (WhatsApp Roster)
 
 **Status:** Live (weekdays + Friday PM, PDT schedule — update UTC times each DST transition)
-**Last reviewed:** March 19, 2026
+**Last reviewed:** March 20, 2026
 
 ---
 
@@ -52,7 +52,7 @@ The endpoint orchestrates the full notify flow:
 
 5. **Generate roster image** — calls `/api/roster-image` (same Vercel deployment) with the roster data. Returns a PNG. Uses AGYD brand colors (Forest Green `#4A773C`, Sage Green `#78A354`).
 
-6. **Send via Twilio WhatsApp** — calls `sendRosterImage()` from `notifyWhatsApp.js`, which sends the PNG to all numbers in `NOTIFY_RECIPIENTS` (comma-separated E.164 numbers).
+6. **Send via Meta Cloud API (WhatsApp)** — calls `sendRosterImage()` from `notifyWhatsApp.js`, which POSTs the PNG to the Meta Graph API and delivers it to all numbers in `NOTIFY_RECIPIENTS` (comma-separated E.164 numbers). Returns a `wamid` per recipient on success.
 
 7. **Store hash** — writes the roster hash and roster data to `cron_health` (`notify` row) so the 7am/8:30am windows can compare against it.
 
@@ -96,12 +96,13 @@ The notify endpoint itself (running in Vercel) also needs these env vars set in 
 
 | Vercel Env Var | Description |
 |---|---|
-| `TWILIO_ACCOUNT_SID` | Twilio account |
-| `TWILIO_AUTH_TOKEN` | Twilio auth token |
-| `TWILIO_FROM_NUMBER` | Twilio sandbox sender number |
+| `META_PHONE_NUMBER_ID` | Sender number ID from the Meta app dashboard |
+| `META_WHATSAPP_TOKEN` | Permanent system user access token — must be assigned to both the QApp and the WhatsApp Business Account in Meta Business Suite |
 | `NOTIFY_RECIPIENTS` | Comma-separated E.164 numbers (Kate + second recipient TBD) |
 | `VITE_SUPABASE_URL` | Supabase project URL |
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role key — bypasses RLS |
+
+**Note:** `TWILIO_*` vars are NOT used by the notify flow. Twilio is only used by the integration check, cron health check, and Gmail monitor (the alerting-only jobs). The roster image notifications use Meta Cloud API exclusively.
 
 ---
 
@@ -116,14 +117,14 @@ The notify endpoint itself (running in Vercel) also needs these env vars set in 
 | `api/notify.js` | Notify orchestrator endpoint (handles all windows incl. friday-pm) |
 | `api/roster-image.js` | PNG image generation endpoint (satori + resvg, token-gated; supports `type=weekend`) |
 | `src/lib/pictureOfDay.js` | `getPictureOfDay()`, `computeWorkerDiff()`, `hashPicture()` |
-| `src/lib/notifyWhatsApp.js` | Twilio wrapper — `sendRosterImage()`, `getRecipients()` |
+| `src/lib/notifyWhatsApp.js` | Meta Cloud API wrapper — `sendRosterImage()`, `sendTextMessage()`, `getRecipients()` |
 
 ---
 
 ## Known Issues / Backlog
 
 - **Second recipient:** `NOTIFY_RECIPIENTS` currently has only Kate's number. Second number to be added when provided (Vercel env var change only — no code change needed).
-- **Twilio sandbox:** currently using the Twilio sandbox sender, which requires recipients to opt in. Move to a Twilio production WhatsApp Business sender before expanding the team distribution.
+- **WhatsApp delivery receipts:** a `wamid` returned by Meta proves the message was accepted, not that it was delivered to the phone. Post-acceptance delivery failures are silent. Meta Webhooks can provide delivery status callbacks — not yet implemented (M3-10).
 - **DST manual update:** each March and November, the UTC times in all **four** `.yml` files need to be updated by hand. No automation exists for this.
 - **`roster-image.js` token check comment:** the comment claims "constant-time comparison" but does not use `crypto.timingSafeEqual`. Low-priority polish — fix the comment or use the API.
 - **`shouldSendNotification` `window` param shadowing:** the parameter named `window` shadows the browser global. Low-priority rename to `sendWindow`.


### PR DESCRIPTION
## Summary
`docs/job_docs/notify-jobs.md` still said Twilio throughout — stale since M0 switched the notify flow to Meta Cloud API.

## Changes
- Step 6: "Send via Twilio WhatsApp" → "Send via Meta Cloud API (WhatsApp)"
- Vercel env vars: replace `TWILIO_*` with `META_PHONE_NUMBER_ID` + `META_WHATSAPP_TOKEN`; add callout that `TWILIO_*` is for alerting-only jobs (integration check, cron health, Gmail monitor)
- Files table: `notifyWhatsApp.js` description corrected to Meta Cloud API wrapper
- Known issues: replace stale Twilio sandbox note with WhatsApp delivery receipt gap (M3-10)

## Test plan
- [ ] CI passes
