### PR TITLE
fix: remove PG from sync title filter — PG boarding appointments now sync (#114)

### DIFF
--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -55,9 +55,12 @@ const PLAYWRIGHT_TIMEOUT_MS = 30_000;
 
 // Mirrors NON_BOARDING_RE from cron-schedule.js and sync.js.
 // Defined here independently — do not import from src/ to preserve signal isolation.
+// NOTE: PG is intentionally excluded. "PG 3/23-30" style titles are pack group
+// BOARDING appointments — Boarding (Nights) pricing passes the pricing filter.
+// PG daycare-only events are rare in the integration check window and would
+// be caught by service category (cat-7431 = PG, not a boarding category).
 const NON_BOARDING_PATTERNS = [
   /(d\/c|\bdc\b)/i,
-  /(p\/g|g\/p|\bpg\b)/i,
   /\badd\b/i,
   /switch\s+day/i,
   /back\s+to\s+\d+/i,

--- a/src/lib/scraper/sync.js
+++ b/src/lib/scraper/sync.js
@@ -357,15 +357,19 @@ export async function runSync(options = {}) {
         //
         // Confirmed non-boarding patterns (business owner verified):
         //   DC:FT / D/C M/T/W/TH  — daycare
-        //   PG FT / P/G MTWTH     — pack group (group daycare)
         //   ADD Leo T/TH           — dog added to recurring daycare schedule
         //   Brinkley switch day    — daycare day swap (not overnight)
         //   mav back to 4 days    — daycare schedule change note
+        //
+        // NOTE: PG (pack group) is intentionally NOT pre-filtered here.
+        // "PG 3/23-30" style titles are pack group BOARDING appointments with
+        // Boarding (Nights) pricing — they pass the pricing filter correctly.
+        // PG daycare-only events are caught by the pricing filter (all line
+        // items match /pack/i dayServicePatterns).
         if (boardingOnly) {
           const titleLower = (appt.title || '').toLowerCase();
           const isKnownNonBoarding =
             /(d\/c|\bdc\b)/i.test(titleLower) ||
-            /(p\/g|g\/p|\bpg\b)/i.test(titleLower) ||
             /\badd\b/i.test(titleLower) ||
             /switch\s+day/i.test(titleLower) ||
             /back\s+to\s+\d+/i.test(titleLower) ||
@@ -406,11 +410,11 @@ export async function runSync(options = {}) {
 
         // Post-fetch filter: catch any non-boarding that slipped past the pre-filter.
         // The service_type from the detail page uses the same shorthand titles.
+        // PG is excluded here for the same reason as the pre-filter — see note above.
         if (boardingOnly) {
           const checkLower = (details.service_type || appt.title || '').toLowerCase();
           const isKnownNonBoarding =
             /(d\/c|\bdc\b)/i.test(checkLower) ||
-            /(p\/g|g\/p|\bpg\b)/i.test(checkLower) ||
             /\badd\b/i.test(checkLower) ||
             /switch\s+day/i.test(checkLower) ||
             /back\s+to\s+\d+/i.test(checkLower) ||


### PR DESCRIPTION
## Summary

- Removes `\bpg\b` from sync.js pre-filter and post-filter title patterns
- Removes same pattern from integration-check.js NON_BOARDING_PATTERNS
- PG daycare-only events are still filtered by the pricing filter (all line items match `/pack/i` day service patterns)
- PG boarding appointments (e.g., "PG 3/23-30") now sync correctly — they have "Boarding (Nights)" pricing which is not a day service

## Root Cause

Kailin had a "PG 3/23-30" appointment (Mar 23-30, $570 boarding). The `\bpg\b` pre-filter was treating all PG-titled appointments as pack group daycare and skipping them before fetching detail or running the pricing filter. PG boarding appointments are legitimate multi-night boardings and must pass through to the pricing filter for correct classification.

## Test Plan

- [ ] `npm run test:run` — all tests pass
- [ ] After merge: trigger manual sync from app SyncSettings to pick up Kailin (C63QgJQ9, Mar 23-30)
- [ ] Confirm Kailin appears in boarding matrix
