### PR TITLE
fix: use 'en' locale for Meta message templates (#121)

### DIFF
--- a/src/__tests__/notifyWhatsApp.test.js
+++ b/src/__tests__/notifyWhatsApp.test.js
@@ -131,7 +131,7 @@ describe('sendRosterImage', () => {
     expect(body.to).toBe('+18312477375');
     expect(body.type).toBe('template');
     expect(body.template.name).toBe('dog_boarding_roster');
-    expect(body.template.language.code).toBe('en_US');
+    expect(body.template.language.code).toBe('en');
     const header = body.template.components[0];
     expect(header.type).toBe('header');
     expect(header.parameters[0].type).toBe('image');
@@ -229,7 +229,7 @@ describe('sendTextMessage', () => {
     expect(body.to).toBe('+18312477375');
     expect(body.type).toBe('template');
     expect(body.template.name).toBe('dog_boarding_alert');
-    expect(body.template.language.code).toBe('en_US');
+    expect(body.template.language.code).toBe('en');
     const bodyComp = body.template.components[0];
     expect(bodyComp.type).toBe('body');
     expect(bodyComp.parameters[0].type).toBe('text');

--- a/src/lib/notifyWhatsApp.js
+++ b/src/lib/notifyWhatsApp.js
@@ -27,7 +27,7 @@ const META_API_VERSION = 'v18.0';
 // Override via env vars if template names differ from defaults.
 const ALERT_TEMPLATE = process.env.META_ALERT_TEMPLATE || 'dog_boarding_alert';
 const ROSTER_TEMPLATE = process.env.META_ROSTER_TEMPLATE || 'dog_boarding_roster';
-const TEMPLATE_LANG = 'en_US';
+const TEMPLATE_LANG = 'en';
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

- Changes `TEMPLATE_LANG` from `'en_US'` to `'en'` in `notifyWhatsApp.js`
- Updates two test assertions to match
- Root cause: templates were created in Meta Business Manager with Language = "English" (`en`), but the code was sending `en_US` — causing error 132001 on every send

## Test plan

- [x] 870 tests, 0 failures (52 files)
- [ ] After merge: trigger integration-check workflow — confirm WhatsApp delivered
- [ ] Tag v5.2.0