### PR TITLE
fix: sanitize newlines in sendTextMessage template parameter (#124)

### DIFF
--- a/src/__tests__/notifyWhatsApp.test.js
+++ b/src/__tests__/notifyWhatsApp.test.js
@@ -257,6 +257,43 @@ describe('sendTextMessage', () => {
     expect(mc()).toHaveLength(0);
     expect(results).toEqual([]);
   });
+
+  it('sanitizes newlines — multi-line message is collapsed to single line with " | " separator', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock([metaOk()]);
+    vi.stubGlobal('fetch', fm);
+
+    const multiLine = '⚠️ Integration check found issues (3/25/26)\nBoarding:\n• Missing from DB: Tula\n• Missing from DB: Fergus';
+    await sendTextMessage(multiLine, ['+18312477375']);
+
+    const body = JSON.parse(mc()[0][1].body);
+    const paramText = body.template.components[0].parameters[0].text;
+    expect(paramText).not.toContain('\n');
+    expect(paramText).toBe('⚠️ Integration check found issues (3/25/26) | Boarding: | • Missing from DB: Tula | • Missing from DB: Fergus');
+  });
+
+  it('sanitizes newlines — trims whitespace per line and drops empty lines', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock([metaOk()]);
+    vi.stubGlobal('fetch', fm);
+
+    // Leading/trailing spaces on lines, empty lines in between
+    const messy = '  First line  \n\n  Second line  \n\n';
+    await sendTextMessage(messy, ['+18312477375']);
+
+    const body = JSON.parse(mc()[0][1].body);
+    const paramText = body.template.components[0].parameters[0].text;
+    expect(paramText).toBe('First line | Second line');
+  });
+
+  it('sanitizes newlines — plain single-line message is unchanged', async () => {
+    const { fetchMock: fm, metaCalls: mc } = makeFetchMock([metaOk()]);
+    vi.stubGlobal('fetch', fm);
+
+    await sendTextMessage('✅ All good', ['+18312477375']);
+
+    const body = JSON.parse(mc()[0][1].body);
+    const paramText = body.template.components[0].parameters[0].text;
+    expect(paramText).toBe('✅ All good');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/notifyWhatsApp.js
+++ b/src/lib/notifyWhatsApp.js
@@ -232,6 +232,11 @@ export async function sendTextMessage(text, recipients) {
     }));
   }
 
+  // Meta template body parameters cannot contain newline or tab characters (error 132018).
+  // Collapse multi-line messages to a single line with ' | ' as the separator.
+  const sanitized = text.split('\n').map(l => l.trim()).filter(Boolean).join(' | ');
+  log(`sendTextMessage body (${sanitized.length} chars): ${sanitized.slice(0, 120)}${sanitized.length > 120 ? '…' : ''}`);
+
   const results = [];
 
   for (const to of recipients) {
@@ -241,7 +246,7 @@ export async function sendTextMessage(text, recipients) {
     try {
       const { messageId } = await metaApiSend(creds.phoneNumberId, creds.token, to,
         buildTemplatePayload(ALERT_TEMPLATE, [
-          { type: 'body', parameters: [{ type: 'text', text }] },
+          { type: 'body', parameters: [{ type: 'text', text: sanitized }] },
         ]),
       );
       log(`Sent to ${masked} — messageId: ${messageId}`);


### PR DESCRIPTION
## Problem

Integration check run 23567443550 revealed that the `en_US` → `en` locale fix (PR #121) resolved error 132001, but every send was then failing with **error 132018**: `Param text cannot have new-line/tab characters or more than 4 consecutive spaces`.

All three alert scripts (`integration-check.js`, `cron-health-check.js`, `gmail-monitor.js`) build multi-line messages with `lines.join('\n')` and pass them directly to `sendTextMessage`, which forwarded the raw text as the `{{1}}` body parameter in the `dog_boarding_alert` template. Meta rejects template parameters containing newlines.

## Fix

Sanitize at the API boundary in `sendTextMessage` (`notifyWhatsApp.js`):
- Split on `\n`, trim each line, drop empty lines, rejoin with ` | `
- Log sanitized body (truncated to 120 chars) for observability

Single-point fix — all three callers get it automatically.

## Tests

3 new tests in `notifyWhatsApp.test.js`:
- Multi-line message collapses to single line with ` | ` separator
- Per-line whitespace trimming + empty line removal
- Single-line message is unchanged

873 tests, 0 failures.
