### PR TITLE
feat: graceful invalid_grant detection in gmail-monitor.js + npm run reauth-gmail (#130)

### DIFF
--- a/docs/job_docs/gmail-monitor.md
+++ b/docs/job_docs/gmail-monitor.md
@@ -52,7 +52,7 @@ From: GitHub Actions
 Subject: [deploy-dog-boarding] Run failed
 Summary: <1-line Claude summary if available>
 ```
-The `Summary:` line is only included when Claude returns a different value than the subject. Falls back to subject if Claude is unavailable or has no credits. Sends to all numbers in `INTEGRATION_CHECK_RECIPIENTS` via Twilio.
+The `Summary:` line is only included when Claude returns a different value than the subject. Falls back to subject if Claude is unavailable or has no credits. Sends to all numbers in `INTEGRATION_CHECK_RECIPIENTS` via Meta Cloud API.
 
 ### Step 6 — Mark processed
 Inserts `{ email_id, sender, subject, alert_sent: true }` into `gmail_processed_emails`. Mark-processed failure is non-fatal (logged as warning) — the alert was already sent.
@@ -117,10 +117,9 @@ All must be **Repository secrets** in GitHub (Settings → Secrets and variables
 | `SUPABASE_SERVICE_ROLE_KEY` | Bypasses RLS — for dedup read/write |
 | `GMAIL_CLIENT_ID` | OAuth2 client ID from Google Cloud Console |
 | `GMAIL_CLIENT_SECRET` | OAuth2 client secret |
-| `GMAIL_REFRESH_TOKEN` | Long-lived token — obtained via one-time local auth flow |
-| `TWILIO_ACCOUNT_SID` | Twilio account SID |
-| `TWILIO_AUTH_TOKEN` | Twilio auth token |
-| `TWILIO_FROM_NUMBER` | Twilio WhatsApp-enabled number |
+| `GMAIL_REFRESH_TOKEN` | Long-lived token — obtained via one-time local auth flow (`npm run reauth-gmail`) |
+| `META_PHONE_NUMBER_ID` | Meta Cloud API phone number ID |
+| `META_WHATSAPP_TOKEN` | Meta Cloud API system user token |
 | `INTEGRATION_CHECK_RECIPIENTS` | Kate's number only (E.164 format, comma-separated for multiple) |
 | `ANTHROPIC_API_KEY` | Optional — Claude 1-line summary. Falls back to subject if absent or no credits |
 
@@ -145,11 +144,25 @@ All must be **Repository secrets** in GitHub (Settings → Secrets and variables
 - The email may have been marked as read before the monitor ran
 - The email may already be in `gmail_processed_emails` — check with: `SELECT * FROM gmail_processed_emails ORDER BY created_at DESC LIMIT 20;`
 
-### OAuth2 error
-The refresh token may be expired or revoked. To re-generate:
-1. Go to Google Cloud Console → the OAuth2 credentials you created
-2. Run the one-time local auth script again to get a new refresh token
-3. Update `GMAIL_REFRESH_TOKEN` in GH repo secrets
+### OAuth2 error — `invalid_grant` (token revoked)
+
+Google returns `invalid_grant` when the refresh token is revoked or expired. This happens when:
+- Kate logs in from a new country (Google treats this as a security event and revokes tokens)
+- The Google account password changes
+- Access is manually revoked in Google Account → Security → Third-party access
+
+**How the monitor handles it:** The script detects `invalid_grant` specifically and exits 0 with a clear message — it does NOT fail the workflow (which would generate its own GH Actions failure email). Monitoring is paused until the token is refreshed.
+
+**How to fix:** run the one-time re-auth flow locally:
+```bash
+GMAIL_CLIENT_ID=<value from GH secrets> GMAIL_CLIENT_SECRET=<value from GH secrets> npm run reauth-gmail
+```
+The script opens a browser, captures the new refresh token, and prints the exact `gh secret set` command to update it. After updating the secret, trigger the Gmail Monitor workflow manually to confirm it works:
+```bash
+/usr/local/bin/gh workflow run gmail-monitor.yml --repo kcoffie/dog-boarding
+```
+
+**Other OAuth errors** (wrong credentials, network failure, etc.) are not `invalid_grant` and will still cause the workflow to exit 1 — those are unexpected failures, not a known state.
 
 ### Alert fired but it was a false positive
 Check `gmail_processed_emails` to confirm the email was recorded. The self-skip guard only suppresses alerts about the Gmail Monitor workflow itself. If a different GH Actions workflow you don't care about is sending alerts, you have two options:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "seed:staging": "VITE_ENVIRONMENT=staging node scripts/seed-test-data.js",
     "test:smoke": "node scripts/smoke-test.js",
     "predeploy": "npm run test:run && npm run test:smoke",
+    "reauth-gmail": "node scripts/get-gmail-refresh-token.js",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/gmail-monitor.js
+++ b/scripts/gmail-monitor.js
@@ -86,8 +86,43 @@ function getSupabase() {
 // ---------------------------------------------------------------------------
 
 /**
+ * Parse a Google OAuth2 error response and classify it.
+ *
+ * Returns `{ type: 'invalid_grant', description }` when Google reports the
+ * refresh token is revoked or expired — a known, recoverable state that
+ * should NOT cause a workflow failure alert.
+ *
+ * Returns `{ type: 'generic', description }` for all other error shapes
+ * (bad credentials, network errors, unexpected status codes, etc.).
+ *
+ * Pure function — exported for testing without fetch mocks.
+ *
+ * @param {number} status - HTTP status code from the token endpoint
+ * @param {object|null} body - Parsed JSON response body, or null if parsing failed
+ * @returns {{ type: 'invalid_grant'|'generic', description: string }}
+ */
+export function detectOAuthError(status, body) {
+  if (status === 400 && body?.error === 'invalid_grant') {
+    const description = body.error_description
+      ? `${body.error_description}`
+      : 'refresh token revoked or expired';
+    return { type: 'invalid_grant', description };
+  }
+
+  const errorLabel = body?.error ? ` (${body.error})` : '';
+  return {
+    type: 'generic',
+    description: `OAuth2 token refresh failed (${status})${errorLabel}`,
+  };
+}
+
+/**
  * Exchange the long-lived refresh token for a short-lived Gmail access token.
  * Called once per script run.
+ *
+ * Throws an error tagged with `err.code = 'GMAIL_INVALID_GRANT'` if Google
+ * reports the refresh token is revoked — so the caller can exit gracefully
+ * rather than treating this as an unexpected infrastructure failure.
  *
  * @returns {Promise<string>} access token
  */
@@ -112,8 +147,18 @@ async function getAccessToken() {
   });
 
   if (!response.ok) {
-    const text = await response.text().catch(() => '(no body)');
-    throw new Error(`OAuth2 token refresh failed (${response.status}): ${text}`);
+    const body = await response.json().catch(() => null);
+    const { type, description } = detectOAuthError(response.status, body);
+
+    if (type === 'invalid_grant') {
+      const err = new Error(`Gmail OAuth token revoked (invalid_grant): ${description}`);
+      err.code = 'GMAIL_INVALID_GRANT';
+      throw err;
+    }
+
+    // Generic OAuth failure — log raw body for debugging
+    const rawBody = body ? JSON.stringify(body) : '(unparseable response)';
+    throw new Error(`${description}: ${rawBody}`);
   }
 
   const data = await response.json();
@@ -428,6 +473,15 @@ async function main() {
 // Only run main() when executed directly — not when imported by tests.
 if (process.argv[1]?.endsWith('gmail-monitor.js')) {
   main().catch(err => {
+    if (err.code === 'GMAIL_INVALID_GRANT') {
+      // Known recoverable state — token revoked (e.g. new country login, password change).
+      // Exit 0 so the workflow does not fail and generate its own "run failed" alert email.
+      console.log('[GmailMonitor] Gmail OAuth token is revoked — monitoring paused until re-authenticated.');
+      console.log('[GmailMonitor] To fix: GMAIL_CLIENT_ID=... GMAIL_CLIENT_SECRET=... npm run reauth-gmail');
+      console.log('[GmailMonitor] Then update GMAIL_REFRESH_TOKEN in GitHub repo secrets.');
+      console.log('[GmailMonitor] Details:', err.message);
+      process.exit(0);
+    }
     console.error('[GmailMonitor] Unhandled error:', err.message, err.stack);
     process.exit(1);
   });

--- a/src/__tests__/gmailMonitor.test.js
+++ b/src/__tests__/gmailMonitor.test.js
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { classifyEmail, SELF_SKIP_SUBJECTS } from '../../scripts/gmail-monitor.js';
+import { classifyEmail, SELF_SKIP_SUBJECTS, detectOAuthError } from '../../scripts/gmail-monitor.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -195,6 +195,56 @@ describe('classifyEmail — unknown sender', () => {
     const { senderConfig, matched } = classifyEmail(email);
     expect(matched).toBe(false);
     expect(senderConfig).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectOAuthError
+// ---------------------------------------------------------------------------
+
+describe('detectOAuthError', () => {
+  it('detects invalid_grant from a 400 response', () => {
+    const result = detectOAuthError(400, { error: 'invalid_grant' });
+    expect(result.type).toBe('invalid_grant');
+  });
+
+  it('includes error_description when present', () => {
+    const result = detectOAuthError(400, {
+      error: 'invalid_grant',
+      error_description: 'Token has been expired or revoked.',
+    });
+    expect(result.type).toBe('invalid_grant');
+    expect(result.description).toContain('Token has been expired or revoked.');
+  });
+
+  it('falls back to generic description when error_description is absent', () => {
+    const result = detectOAuthError(400, { error: 'invalid_grant' });
+    expect(result.type).toBe('invalid_grant');
+    expect(result.description).toMatch(/revoked or expired/);
+  });
+
+  it('returns generic for invalid_client (wrong credentials — not the revoked-token case)', () => {
+    const result = detectOAuthError(400, { error: 'invalid_client' });
+    expect(result.type).toBe('generic');
+    expect(result.description).toContain('invalid_client');
+  });
+
+  it('returns generic for a 500 error', () => {
+    const result = detectOAuthError(500, { error: 'server_error' });
+    expect(result.type).toBe('generic');
+    expect(result.description).toContain('500');
+  });
+
+  it('returns generic when body is null (JSON parse failed)', () => {
+    const result = detectOAuthError(400, null);
+    expect(result.type).toBe('generic');
+    expect(result.description).toContain('400');
+  });
+
+  it('returns generic for a non-400 invalid_grant (unexpected shape — treat as generic)', () => {
+    // Google always returns 400 for invalid_grant, but guard against an edge case
+    const result = detectOAuthError(401, { error: 'invalid_grant' });
+    expect(result.type).toBe('generic');
   });
 });
 


### PR DESCRIPTION
## Summary

- **`detectOAuthError(status, body)`** — new pure exported function that identifies `invalid_grant` (token revoked/expired) vs all other OAuth failures. Testable without fetch mocks.
- **`getAccessToken()`** — now parses the Google error JSON; throws `err.code = 'GMAIL_INVALID_GRANT'` for `invalid_grant` instead of a generic error.
- **`main().catch()`** — intercepts `GMAIL_INVALID_GRANT` and exits 0 with clear recovery instructions. The workflow no longer "fails" for a known, expected state — which breaks the potential alert loop (workflow fail → GH Actions email → Gmail monitor alert → repeat).
- **`npm run reauth-gmail`** — added to `package.json` as a shortcut for `node scripts/get-gmail-refresh-token.js`.
- **`docs/job_docs/gmail-monitor.md`** — updated OAuth error section with `npm run reauth-gmail` instructions; fixed two stale Twilio refs.

## Exit behavior comparison

| Scenario | Before | After |
|---|---|---|
| Token revoked (`invalid_grant`) | exit 1 → workflow fails → GH email | exit 0 → silent, logs recovery steps |
| Wrong credentials (`invalid_client`) | exit 1 | exit 1 (still unexpected failure) |
| Network error | exit 1 | exit 1 |

## Test plan

- [x] `detectOAuthError` — 7 new unit tests covering: `invalid_grant` detection, `error_description` inclusion, generic fallback for `invalid_client`, 500 errors, null body, non-400 status
- [x] All 915 existing tests passing (53 files)
- [x] `npm run reauth-gmail` resolves to `scripts/get-gmail-refresh-token.js`

Closes #130