### PR TITLE
fix: filter Daycare Add-On Day false positive in integration check (#177)

### DIFF
--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -78,7 +78,7 @@ function isBoardingTitle(title) {
 // check context where the pricing filter (which correctly excludes daycares)
 // cannot run without fetching detail pages.
 //
-// Confirmed false positives (31 total March 2026; +2 April 2026):
+// Confirmed false positives (31 total March 2026; +2 April 2026; +1 April 2026):
 //   - PG daycare with delimiters: "P/G M/T/W/Th", "PG:FT", "PG: MWTH OFF OFF", etc.
 //   - PG daycare with concatenated days: "P/G MTWTH", "P/G TWTH", "PG:WTH"
 //   - Make up days: "Moonbeam — Make up days T.F"
@@ -89,6 +89,10 @@ function isBoardingTitle(title) {
 //     The sync filters this via the detail-page service_type ("Initial Evaluation"
 //     matches /initial\s+eval/i in nonBoardingPatterns); the integration check only
 //     sees the schedule title, so the N/C prefix must be caught here.
+//   - Daycare Add-On Day: "4/21" (bare date, no range) — April 2026. These appear as
+//     /schedule/a/ boarding-style links but the sync skips them via pricing: "all day
+//     services (Daycare Add-On Day)". Real overnight boardings always show a date range
+//     like "4/21-25"; a bare date is never an overnight stay.
 //
 // Two PG patterns are needed:
 //   1. Delimited days — uses \b word boundaries (catches M/T/W/Th, PG FT, etc.)
@@ -101,6 +105,7 @@ const DAYCARE_ONLY_PATTERNS = [
   /no charge/i,
   /\bdaycare\b/i,
   /\bN\/C\b/i,
+  /^\d+\/\d+$/, // bare date "4/21" — Daycare Add-On Day; real boardings show ranges like "4/21-25"
 ];
 function isDaycareOnlyTitle(title) {
   return DAYCARE_ONLY_PATTERNS.some(re => re.test(title));

--- a/src/__tests__/integrationCheckFilter.test.js
+++ b/src/__tests__/integrationCheckFilter.test.js
@@ -3,8 +3,8 @@
  *
  * The `isDaycareOnlyTitle` function lives in scripts/integration-check.js and
  * cannot be imported (it's a standalone script). These tests mirror the exact
- * patterns and validate the confirmed false positives (31 March 2026; +2 April 2026)
- * plus a set of real boardings that must NOT be filtered.
+ * patterns and validate the confirmed false positives (31 March 2026; +2 April 2026;
+ * +1 April 2026 Daycare Add-On Day) plus a set of real boardings that must NOT be filtered.
  *
  * If you change DAYCARE_ONLY_PATTERNS in integration-check.js, update here too.
  */
@@ -19,6 +19,7 @@ const DAYCARE_ONLY_PATTERNS = [
   /no charge/i,
   /\bdaycare\b/i,
   /\bN\/C\b/i,
+  /^\d+\/\d+$/, // bare date "4/21" — Daycare Add-On Day; real boardings show ranges like "4/21-25"
 ];
 
 function isDaycareOnlyTitle(title) {
@@ -69,6 +70,12 @@ const FALSE_POSITIVES = [
   // Sync filters this via detail-page service_type; integration check only sees schedule title.
   'N/C Tula 3/23-26',
   'N/C Buddy 4/1',
+  // Daycare Add-On Day (added April 2026 — #177)
+  // Appears as /schedule/a/ boarding link but pricing says "all day services (Daycare Add-On Day)".
+  // Title is a bare date with no range — overnight boardings always show a range like "4/21-25".
+  '4/21',
+  '3/5',
+  '12/31',
 ];
 
 // ─── Real boardings (must NOT be filtered) ────────────────────────────────────
@@ -82,6 +89,9 @@ const REAL_BOARDINGS = [
   'Daisy 4/5-10 PG',
   'Staff Boarding (nights)',
   'Charlie 3/28-31',
+  '4/21-25',             // bare date WITH range — real boarding (new; guards against over-filtering)
+  '4/21-21',             // same-day range format
+  '3/5-8',
 ];
 
 // ─── Tests ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds `/^\d+\/\d+$/` to `DAYCARE_ONLY_PATTERNS` in `scripts/integration-check.js`.

## Why

"Daycare Add-On Day" appointments appear on the AGYD schedule as `/schedule/a/` boarding-style links — the same format as real boardings. Their title is a bare date like `"4/21"` with no date range. The sync pipeline correctly identifies them as all-day services from the detail page and skips them, so they never land in the DB. The integration check can't fetch detail pages (signal isolation), so it saw a boarding link with no DB record and fired a false positive.

**Observed 4/21/2026:** `C63QggUE` — Mabel, title `"4/21"`, sync skip reason: `pricing: all day services (Daycare Add-On Day)`.

## How

Real overnight boardings always show a date range (`"4/21-25"`). A bare date with no range (`"4/21"`) is never an overnight stay. The new pattern matches the bare-date form and is safe — `"4/21-25"` does not match.

## Tests

- 3 new false-positive cases: `"4/21"`, `"3/5"`, `"12/31"`
- 3 new real-boarding guard cases: `"4/21-25"`, `"4/21-21"`, `"3/5-8"`
- 47 tests total, all pass
