### PR TITLE
feat: F-2 message log — record all WhatsApp sends + /messages page (#181)

### DIFF
--- a/api/notify.js
+++ b/api/notify.js
@@ -33,7 +33,7 @@ import {
   sendTextMessage,
   getRecipients,
 } from '../src/lib/notifyWhatsApp.js';
-import { recordSentMessages } from '../src/lib/messageDeliveryStatus.js';
+import { recordSentMessages, recordMessageLog } from '../src/lib/messageDeliveryStatus.js';
 import { writeCronHealth } from './_cronHealth.js';
 import { refreshDaytimeSchedule } from '../src/lib/notifyHelpers.js';
 
@@ -93,6 +93,10 @@ async function sendRefreshAlert(supabase, warning, dateStr, notifyWindow) {
   await recordSentMessages(supabase, refreshResults, 'notify-refresh-alert').catch(err =>
     console.warn(`[Notify/RefreshAlert] Failed to record delivery status: ${err.message}`)
   );
+  console.log(`[Notify] Recording message_log — job: notify-refresh-alert, content length: ${body.length} chars`);
+  await recordMessageLog(supabase, refreshResults, 'notify-refresh-alert', 'text', body, null).catch(err =>
+    console.warn(`[Notify/RefreshAlert] Failed to record message_log: ${err.message}`)
+  );
 
   // Record that we sent the alert for this date (non-fatal)
   await writeCronHealth(supabase, 'notify-refresh-alert', 'success', {
@@ -110,6 +114,61 @@ function getSupabase() {
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
   if (!url || !key) throw new Error('Supabase env vars not configured');
   return createClient(url, key);
+}
+
+/**
+ * Fetch the roster image PNG from imageUrl and upload it to Supabase Storage.
+ * Returns the storage path (e.g. 'roster-images/notify-4am/2026-04-22T11:00:00.000Z.png')
+ * or null if the fetch or upload fails. Non-fatal — failures are logged and swallowed
+ * so the caller can still record the message_log row with a null image_path.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} imageUrl  - Full URL to /api/roster-image (auth token included)
+ * @param {string} jobName   - e.g. 'notify-4am', 'notify-friday-pm'
+ * @param {string} jobRunAt  - ISO timestamp captured at handler entry
+ * @returns {Promise<string|null>}
+ */
+async function storeRosterImage(supabase, imageUrl, jobName, jobRunAt) {
+  const logHost = new URL(imageUrl).host;
+  console.log(`[ImageStore] Fetching image for storage — host: ${logHost}, job: ${jobName}`);
+
+  let buffer;
+  try {
+    const response = await fetch(imageUrl);
+    if (!response.ok) {
+      console.warn(`[ImageStore] Image fetch failed (HTTP ${response.status}) — skipping storage, message_log row will have null image_path`);
+      return null;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    buffer = Buffer.from(arrayBuffer);
+    console.log(`[ImageStore] Fetched ${buffer.length} bytes`);
+  } catch (err) {
+    console.warn(`[ImageStore] Image fetch error: ${err.message} — skipping storage, message_log row will have null image_path`);
+    return null;
+  }
+
+  // Safe filename: replace colons in the ISO timestamp so all storage backends accept it
+  const safeTimestamp = jobRunAt.replace(/:/g, '-');
+  const pathInBucket = `${jobName}/${safeTimestamp}.png`;
+  const fullPath = `roster-images/${pathInBucket}`;
+  console.log(`[ImageStore] Uploading to Supabase Storage — path: ${fullPath}`);
+
+  try {
+    const { error } = await supabase.storage
+      .from('roster-images')
+      .upload(pathInBucket, buffer, { contentType: 'image/png', upsert: true });
+
+    if (error) {
+      console.warn(`[ImageStore] Storage upload failed: ${error.message} — skipping storage, message_log row will have null image_path`);
+      return null;
+    }
+  } catch (err) {
+    console.warn(`[ImageStore] Storage upload error: ${err.message} — skipping storage, message_log row will have null image_path`);
+    return null;
+  }
+
+  console.log(`[ImageStore] Upload complete — ${fullPath}`);
+  return fullPath;
 }
 
 /**
@@ -210,6 +269,11 @@ export default async function handler(req, res) {
       const sendResults = await sendRosterImage(imageUrl, recipients);
       await recordSentMessages(supabase, sendResults, 'notify-friday-pm').catch(err =>
         console.warn(`[Notify] Failed to record delivery status (friday-pm): ${err.message}`)
+      );
+      const fridayImagePath = await storeRosterImage(supabase, imageUrl, 'notify-friday-pm', jobRunAt);
+      console.log(`[Notify] Storing roster image and recording message_log — job: notify-friday-pm, imagePath: ${fridayImagePath ?? 'null'}`);
+      await recordMessageLog(supabase, sendResults, 'notify-friday-pm', 'image', null, fridayImagePath).catch(err =>
+        console.warn(`[Notify] Failed to record message_log (friday-pm): ${err.message}`)
       );
       await writeCronHealth(supabase, 'notify-friday-pm', 'success', {
         sentAt: new Date().toISOString(),
@@ -339,6 +403,13 @@ export default async function handler(req, res) {
     // --- Record wamids for delivery observability (non-fatal) ---
     await recordSentMessages(supabase, sendResults, `notify-${window}`).catch(err =>
       console.warn(`[Notify] Failed to record delivery status (${window}): ${err.message}`)
+    );
+
+    // --- Store roster image + record message log (non-fatal) ---
+    const imagePath = await storeRosterImage(supabase, imageUrl, `notify-${window}`, jobRunAt);
+    console.log(`[Notify] Storing roster image and recording message_log — job: notify-${window}, imagePath: ${imagePath ?? 'null'}`);
+    await recordMessageLog(supabase, sendResults, `notify-${window}`, 'image', null, imagePath).catch(err =>
+      console.warn(`[Notify] Failed to record message_log (${window}): ${err.message}`)
     );
 
     // --- Persist state (non-fatal) ---

--- a/scripts/cron-health-check.js
+++ b/scripts/cron-health-check.js
@@ -26,7 +26,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { sendTextMessage, getAlertRecipients } from '../src/lib/notifyWhatsApp.js';
-import { recordSentMessages } from '../src/lib/messageDeliveryStatus.js';
+import { recordSentMessages, recordMessageLog } from '../src/lib/messageDeliveryStatus.js';
 
 // The three midnight Vercel crons we monitor.
 const MONITORED_CRONS = ['auth', 'schedule', 'detail'];
@@ -191,6 +191,10 @@ async function sendAlertMessage(message, supabase = null) {
   console.log('[CronHealthCheck] WhatsApp: %d/%d sent', sent, recipients.length);
   await recordSentMessages(supabase, results, 'cron-health-check').catch(err =>
     console.warn('[CronHealthCheck] Failed to record delivery status: %s', err.message)
+  );
+  console.log('[CronHealthCheck] Recording message_log — job: cron-health-check, content length: %d chars', message.length);
+  await recordMessageLog(supabase, results, 'cron-health-check', 'text', message, null).catch(err =>
+    console.warn('[CronHealthCheck] Failed to record message_log: %s', err.message)
   );
 }
 

--- a/scripts/gmail-monitor.js
+++ b/scripts/gmail-monitor.js
@@ -30,7 +30,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { sendTextMessage, getAlertRecipients } from '../src/lib/notifyWhatsApp.js';
-import { recordSentMessages } from '../src/lib/messageDeliveryStatus.js';
+import { recordSentMessages, recordMessageLog } from '../src/lib/messageDeliveryStatus.js';
 
 // ---------------------------------------------------------------------------
 // Known sender configuration
@@ -355,6 +355,10 @@ async function sendAlertMessage(message, supabase = null) {
   console.log('[GmailMonitor] WhatsApp: %d/%d sent', sent, recipients.length);
   await recordSentMessages(supabase, results, 'gmail-monitor').catch(err =>
     console.warn('[GmailMonitor] Failed to record delivery status: %s', err.message)
+  );
+  console.log('[GmailMonitor] Recording message_log — job: gmail-monitor, content length: %d chars', message.length);
+  await recordMessageLog(supabase, results, 'gmail-monitor', 'text', message, null).catch(err =>
+    console.warn('[GmailMonitor] Failed to record message_log: %s', err.message)
   );
 }
 

--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -47,7 +47,7 @@ import { chromium } from 'playwright';
 import Anthropic from '@anthropic-ai/sdk';
 import { createClient } from '@supabase/supabase-js';
 import { sendTextMessage, getAlertRecipients } from '../src/lib/notifyWhatsApp.js';
-import { recordSentMessages } from '../src/lib/messageDeliveryStatus.js';
+import { recordSentMessages, recordMessageLog } from '../src/lib/messageDeliveryStatus.js';
 import { runScheduleSync, runDetailSync } from '../src/lib/scraper/syncRunner.js';
 import { resetStuck } from '../src/lib/scraper/syncQueue.js';
 import { SCRAPER_CONFIG } from '../src/lib/scraper/config.js';
@@ -514,9 +514,13 @@ async function sendAlertMessage(message, supabase = null) {
   const results = await sendTextMessage(message, recipients);
   const sent = results.filter(r => r.status === 'sent').length;
   console.log('[IntegCheck] WhatsApp: %d/%d sent', sent, recipients.length);
-  // supabase is null at startup-crash call site — recordSentMessages handles null gracefully.
+  // supabase is null at startup-crash call site — both record* functions handle null gracefully.
   await recordSentMessages(supabase, results, 'integration-check').catch(err =>
     console.warn('[IntegCheck] Failed to record delivery status: %s', err.message)
+  );
+  console.log('[IntegCheck] Recording message_log — job: integration-check, content length: %d chars', message.length);
+  await recordMessageLog(supabase, results, 'integration-check', 'text', message, null).catch(err =>
+    console.warn('[IntegCheck] Failed to record message_log: %s', err.message)
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import PayrollPage from './pages/PayrollPage';
 import CalendarPage from './pages/CalendarPage';
 import ProfilePage from './pages/ProfilePage';
 import SyncHistoryPage from './pages/SyncHistoryPage';
+import MessageLogPage from './pages/MessageLogPage';
 import ProtectedRoute from './components/auth/ProtectedRoute';
 import LoginPage from './pages/auth/LoginPage';
 import SignupPage from './pages/auth/SignupPage';
@@ -48,6 +49,7 @@ function App() {
             <Route path="payroll" element={<PayrollPage />} />
             <Route path="settings" element={<SettingsPage />} />
             <Route path="sync-history" element={<SyncHistoryPage />} />
+            <Route path="messages" element={<MessageLogPage />} />
             <Route path="profile" element={<ProfilePage />} />
           </Route>
         </Routes>

--- a/src/__tests__/MessageLogPage.test.jsx
+++ b/src/__tests__/MessageLogPage.test.jsx
@@ -1,0 +1,132 @@
+/**
+ * Smoke tests for MessageLogPage.
+ * @requirements REQ-v5.0-F2
+ *
+ * Tests the page's rendering states (loading, error, empty, populated)
+ * by mocking the useMessageLog hook at the module level.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MessageLogPage from '../pages/MessageLogPage';
+
+vi.mock('../hooks/useMessageLog', () => ({
+  useMessageLog: vi.fn(),
+}));
+
+import { useMessageLog } from '../hooks/useMessageLog';
+
+const SAMPLE_ROWS = [
+  {
+    id: 1,
+    sent_at: '2026-04-22T11:00:00.000Z',
+    job_name: 'notify-4am',
+    message_type: 'image',
+    recipient: '***-***-7375',
+    content: null,
+    image_path: 'roster-images/notify-4am/2026-04-22.png',
+    signedUrl: 'https://example.com/signed/image.png',
+    wamid: 'wamid.abc123',
+    status: 'sent',
+  },
+  {
+    id: 2,
+    sent_at: '2026-04-22T11:00:00.000Z',
+    job_name: 'cron-health-check',
+    message_type: 'text',
+    recipient: '***-***-7375',
+    content: '⚠️ cron-auth: 2 consecutive failure(s)',
+    image_path: null,
+    signedUrl: null,
+    wamid: 'wamid.def456',
+    status: 'sent',
+  },
+  {
+    id: 3,
+    sent_at: '2026-04-22T04:00:00.000Z',
+    job_name: 'notify-4am',
+    message_type: 'image',
+    recipient: '***-***-5462',
+    content: null,
+    image_path: null,
+    signedUrl: null,
+    wamid: null,
+    status: 'failed',
+  },
+];
+
+describe('MessageLogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a loading indicator while loading', () => {
+    useMessageLog.mockReturnValue({ rows: [], loading: true, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    // Spinner SVG is present (animate-spin class)
+    expect(document.querySelector('.animate-spin')).toBeTruthy();
+  });
+
+  it('shows an error alert when loading fails', () => {
+    useMessageLog.mockReturnValue({
+      rows: [],
+      loading: false,
+      error: 'connection refused',
+      refresh: vi.fn(),
+    });
+    render(<MessageLogPage />);
+    expect(screen.getByText('Error loading messages')).toBeInTheDocument();
+    expect(screen.getByText('connection refused')).toBeInTheDocument();
+  });
+
+  it('shows empty state when there are no rows', () => {
+    useMessageLog.mockReturnValue({ rows: [], loading: false, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    expect(screen.getByText('No messages in the last 5 days')).toBeInTheDocument();
+  });
+
+  it('renders the page heading', () => {
+    useMessageLog.mockReturnValue({ rows: SAMPLE_ROWS, loading: false, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    expect(screen.getByText('Messages')).toBeInTheDocument();
+    expect(screen.getByText('Outbound WhatsApp sends — last 5 days')).toBeInTheDocument();
+  });
+
+  it('renders a table row for each message', () => {
+    useMessageLog.mockReturnValue({ rows: SAMPLE_ROWS, loading: false, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    // Each row has a job name cell
+    expect(screen.getAllByText('notify-4am')).toHaveLength(2);
+    expect(screen.getByText('cron-health-check')).toBeInTheDocument();
+  });
+
+  it('renders an img tag for image rows that have a signed URL', () => {
+    useMessageLog.mockReturnValue({ rows: SAMPLE_ROWS, loading: false, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    const img = screen.getByRole('img', { name: /Roster for notify-4am/ });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/signed/image.png');
+  });
+
+  it('renders text content for text rows', () => {
+    useMessageLog.mockReturnValue({ rows: SAMPLE_ROWS, loading: false, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    expect(screen.getByText(/cron-auth: 2 consecutive failure/)).toBeInTheDocument();
+  });
+
+  it('shows "failed" badge for failed send rows', () => {
+    useMessageLog.mockReturnValue({ rows: SAMPLE_ROWS, loading: false, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    const failedBadges = screen.getAllByText('failed');
+    expect(failedBadges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows summary stats: total, sent, failed counts', () => {
+    useMessageLog.mockReturnValue({ rows: SAMPLE_ROWS, loading: false, error: null, refresh: vi.fn() });
+    render(<MessageLogPage />);
+    // Total = 3, Sent = 2, Failed = 1
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/messageDeliveryStatus.test.js
+++ b/src/__tests__/messageDeliveryStatus.test.js
@@ -1,14 +1,15 @@
 /**
  * Tests for src/lib/messageDeliveryStatus.js
- * @requirements REQ-v5.0-F1
+ * @requirements REQ-v5.0-F1, REQ-v5.0-F2
  *
- * Covers both write paths:
- *   recordSentMessages  — called at send time
+ * Covers all three write paths:
+ *   recordSentMessages   — called at send time (successful sends only)
+ *   recordMessageLog     — called at send time (ALL sends, for message_log table)
  *   upsertDeliveryStatus — called by the Meta webhook handler
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { recordSentMessages, upsertDeliveryStatus } from '../lib/messageDeliveryStatus.js';
+import { recordSentMessages, recordMessageLog, upsertDeliveryStatus } from '../lib/messageDeliveryStatus.js';
 
 // ---------------------------------------------------------------------------
 // Supabase mock factory
@@ -16,15 +17,18 @@ import { recordSentMessages, upsertDeliveryStatus } from '../lib/messageDelivery
 
 /**
  * Build a lightweight Supabase client mock.
- * upsertResponse: { error: null } by default (success).
+ * upsertError / insertError control which operation fails.
  */
-function makeSupabase({ upsertError = null } = {}) {
+function makeSupabase({ upsertError = null, insertError = null } = {}) {
   const upsertSpy = vi.fn().mockResolvedValue({ error: upsertError });
+  const insertSpy = vi.fn().mockResolvedValue({ error: insertError });
   return {
     from: vi.fn().mockReturnValue({
       upsert: upsertSpy,
+      insert: insertSpy,
     }),
     _upsertSpy: upsertSpy,
+    _insertSpy: insertSpy,
   };
 }
 
@@ -111,6 +115,87 @@ describe('recordSentMessages', () => {
     const results = [{ to: '***-***-7375', status: 'sent', messageId: 'wamid.fff' }];
 
     await expect(recordSentMessages(null, results, 'integration-check')).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordMessageLog
+// ---------------------------------------------------------------------------
+
+describe('recordMessageLog', () => {
+  it('inserts one row per result — records both sent and failed sends', async () => {
+    const supabase = makeSupabase();
+    const results = [
+      { to: '***-***-7375', status: 'sent',   messageId: 'wamid.aaa' },
+      { to: '***-***-5462', status: 'failed', error: 'Meta API 500' },
+    ];
+
+    await recordMessageLog(supabase, results, 'notify-4am', 'text', 'hello world', null);
+
+    expect(supabase.from).toHaveBeenCalledWith('message_log');
+    const [rows] = supabase._insertSpy.mock.calls[0];
+    expect(rows).toHaveLength(2);
+
+    const sentRow = rows.find(r => r.recipient === '***-***-7375');
+    expect(sentRow.status).toBe('sent');
+    expect(sentRow.wamid).toBe('wamid.aaa');
+    expect(sentRow.job_name).toBe('notify-4am');
+    expect(sentRow.message_type).toBe('text');
+    expect(sentRow.content).toBe('hello world');
+    expect(sentRow.image_path).toBeNull();
+
+    const failedRow = rows.find(r => r.recipient === '***-***-5462');
+    expect(failedRow.status).toBe('failed');
+    expect(failedRow.wamid).toBeNull();
+  });
+
+  it('records image rows with imagePath and null content', async () => {
+    const supabase = makeSupabase();
+    const results = [{ to: '***-***-7375', status: 'sent', messageId: 'wamid.bbb' }];
+
+    await recordMessageLog(supabase, results, 'notify-friday-pm', 'image', null, 'roster-images/notify-friday-pm/2026-04-22.png');
+
+    const [rows] = supabase._insertSpy.mock.calls[0];
+    expect(rows[0].message_type).toBe('image');
+    expect(rows[0].content).toBeNull();
+    expect(rows[0].image_path).toBe('roster-images/notify-friday-pm/2026-04-22.png');
+    expect(rows[0].wamid).toBe('wamid.bbb');
+  });
+
+  it('failed send rows have null wamid even if messageId is present', async () => {
+    const supabase = makeSupabase();
+    const results = [{ to: '***-***-7375', status: 'failed', messageId: 'should-be-ignored' }];
+
+    await recordMessageLog(supabase, results, 'cron-health-check', 'text', 'alert', null);
+
+    const [rows] = supabase._insertSpy.mock.calls[0];
+    expect(rows[0].status).toBe('failed');
+    expect(rows[0].wamid).toBeNull();
+  });
+
+  it('is non-fatal — swallows DB errors without throwing', async () => {
+    const supabase = makeSupabase({ insertError: { message: 'DB unavailable' } });
+    const results = [{ to: '***-***-7375', status: 'sent', messageId: 'wamid.ccc' }];
+
+    await expect(
+      recordMessageLog(supabase, results, 'gmail-monitor', 'text', 'msg', null)
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips DB write when supabase is null', async () => {
+    const results = [{ to: '***-***-7375', status: 'sent', messageId: 'wamid.ddd' }];
+
+    await expect(
+      recordMessageLog(null, results, 'integration-check', 'text', 'msg', null)
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips DB write when results array is empty', async () => {
+    const supabase = makeSupabase();
+
+    await recordMessageLog(supabase, [], 'notify-4am', 'text', null, null);
+
+    expect(supabase._insertSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -100,6 +100,15 @@ export default function Layout() {
         </svg>
       ),
     },
+    {
+      to: '/messages',
+      label: 'Messages',
+      icon: (
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+        </svg>
+      ),
+    },
   ];
 
   return (

--- a/src/hooks/useMessageLog.js
+++ b/src/hooks/useMessageLog.js
@@ -1,0 +1,106 @@
+/**
+ * Hook for fetching the last 5 days of outbound WhatsApp messages from
+ * message_log, with signed URLs generated for image rows so the page
+ * can render the actual roster PNG inline.
+ *
+ * @requirements REQ-v5.0-F2
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+
+const DAYS_WINDOW = 5;
+const SIGNED_URL_TTL_SECONDS = 3600;
+
+/**
+ * Fetch message_log rows for the last N days, ordered newest-first.
+ * @returns {Promise<Array>}
+ */
+async function fetchMessageLog() {
+  const cutoff = new Date(Date.now() - DAYS_WINDOW * 24 * 60 * 60 * 1000).toISOString();
+  console.log(`[MessageLog] Loading — cutoff: ${cutoff}`);
+
+  const { data, error } = await supabase
+    .from('message_log')
+    .select('*')
+    .gte('sent_at', cutoff)
+    .order('sent_at', { ascending: false });
+
+  if (error) {
+    console.error(`[MessageLog] Load failed: ${error.message}`);
+    throw error;
+  }
+
+  return data || [];
+}
+
+/**
+ * Generate signed URLs for rows where image_path is set.
+ * image_path format: 'roster-images/{jobName}/{timestamp}.png'
+ * The bucket name is stripped before calling createSignedUrl.
+ *
+ * Returns the rows array with a signedUrl property injected on image rows.
+ * Errors generating individual URLs are logged but do not fail the whole load.
+ *
+ * @param {Array} rows
+ * @returns {Promise<Array>}
+ */
+async function injectSignedUrls(rows) {
+  const imageRows = rows.filter(r => r.image_path);
+  if (imageRows.length === 0) return rows;
+
+  console.log(`[MessageLog] Loaded ${rows.length} rows — generating signed URLs for ${imageRows.length} image rows`);
+
+  const withUrls = await Promise.all(
+    rows.map(async row => {
+      if (!row.image_path) return row;
+
+      // image_path is stored as 'roster-images/{path}' — strip the bucket prefix
+      const pathInBucket = row.image_path.replace(/^roster-images\//, '');
+
+      const { data, error } = await supabase.storage
+        .from('roster-images')
+        .createSignedUrl(pathInBucket, SIGNED_URL_TTL_SECONDS);
+
+      if (error) {
+        console.warn(`[MessageLog] Signed URL failed for ${row.image_path}: ${error.message}`);
+        return { ...row, signedUrl: null };
+      }
+
+      console.log(`[MessageLog] Signed URL generated for ${row.image_path}`);
+      return { ...row, signedUrl: data.signedUrl };
+    })
+  );
+
+  return withUrls;
+}
+
+export function useMessageLog() {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const rawRows = await fetchMessageLog();
+      const enriched = await injectSignedUrls(rawRows);
+      setRows(enriched);
+    } catch (err) {
+      console.error('[MessageLog] useMessageLog load error:', err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { rows, loading, error, refresh: load };
+}
+
+export default useMessageLog;

--- a/src/lib/messageDeliveryStatus.js
+++ b/src/lib/messageDeliveryStatus.js
@@ -72,6 +72,63 @@ export async function recordSentMessages(supabase, results, sendJob) {
 }
 
 /**
+ * Write one row per send result (both sent and failed) to message_log.
+ *
+ * Unlike recordSentMessages, this records ALL send attempts including failures:
+ * failed rows have status='failed' and wamid=null. The whole point is a complete
+ * outbound audit trail that the /messages page can render.
+ *
+ * Non-fatal — a DB error is logged and swallowed so the caller's flow is
+ * never blocked.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient|null} supabase
+ * @param {Array<{to: string, status: string, messageId?: string, error?: string}>} results
+ * @param {string} jobName      - e.g. 'notify-4am', 'cron-health-check'
+ * @param {'image'|'text'} messageType
+ * @param {string|null} content       - text body for 'text'; null for 'image'
+ * @param {string|null} imagePath     - Supabase Storage path for 'image'; null for 'text'
+ * @returns {Promise<void>}
+ */
+export async function recordMessageLog(supabase, results, jobName, messageType, content, imagePath) {
+  if (!supabase) {
+    console.log(`[MessageLog] recordMessageLog("${jobName}") — no supabase client, skipping`);
+    return;
+  }
+
+  if (!results || results.length === 0) {
+    console.log(`[MessageLog] recordMessageLog("${jobName}") — no results to record`);
+    return;
+  }
+
+  console.log(`[MessageLog] recordMessageLog("${jobName}", type=${messageType}, ${results.length} results)`);
+
+  const rows = results.map(r => {
+    const row = {
+      job_name:     jobName,
+      message_type: messageType,
+      recipient:    r.to,
+      content:      content ?? null,
+      image_path:   imagePath ?? null,
+      wamid:        r.status === 'sent' ? (r.messageId ?? null) : null,
+      status:       r.status === 'sent' ? 'sent' : 'failed',
+    };
+    console.log(
+      `[MessageLog] Writing row — recipient: ${r.to}, wamid: ${row.wamid ?? 'null'}, status: ${row.status}` +
+      (imagePath ? `, image_path: ${imagePath}` : '')
+    );
+    return row;
+  });
+
+  const { error } = await supabase.from('message_log').insert(rows);
+
+  if (error) {
+    console.warn(`[MessageLog] DB write failed for job "${jobName}" (type=${messageType}, ${rows.length} rows): ${error.message}`);
+  } else {
+    console.log(`[MessageLog] Wrote ${rows.length} row(s) for job "${jobName}"`);
+  }
+}
+
+/**
  * Upsert a delivery status event received from a Meta webhook POST.
  * Called once per status entry in the webhook payload.
  *

--- a/src/pages/MessageLogPage.jsx
+++ b/src/pages/MessageLogPage.jsx
@@ -1,0 +1,234 @@
+/**
+ * Message Log page — shows the last 5 days of outbound WhatsApp sends.
+ *
+ * Decouples "did the job run?" from "did the message go out?" — open this
+ * page when delivery is in question to see exactly what was sent, to whom,
+ * and whether the roster image looks correct.
+ *
+ * @requirements REQ-v5.0-F2
+ */
+
+import { useMessageLog } from '../hooks/useMessageLog';
+
+const STATUS_STYLES = {
+  sent:   'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200',
+  failed: 'bg-red-50 text-red-700 ring-1 ring-red-200',
+};
+
+const TYPE_STYLES = {
+  image: 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200',
+  text:  'bg-slate-100 text-slate-600 ring-1 ring-slate-200',
+};
+
+function Badge({ text, className }) {
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium ${className}`}>
+      {text}
+    </span>
+  );
+}
+
+function formatTime(isoStr) {
+  if (!isoStr) return '—';
+  return new Date(isoStr).toLocaleString('en-US', {
+    timeZone: 'America/Los_Angeles',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+}
+
+function truncateWamid(wamid) {
+  if (!wamid) return '—';
+  return wamid.length > 24 ? `${wamid.slice(0, 12)}…${wamid.slice(-8)}` : wamid;
+}
+
+function ImageCell({ row }) {
+  if (!row.image_path) return <span className="text-slate-400 text-sm">—</span>;
+
+  if (!row.signedUrl) {
+    return (
+      <span className="text-slate-400 text-sm italic">
+        {row.status === 'failed' ? 'send failed' : 'no image stored'}
+      </span>
+    );
+  }
+
+  return (
+    <a href={row.signedUrl} target="_blank" rel="noopener noreferrer">
+      <img
+        src={row.signedUrl}
+        alt={`Roster for ${row.job_name}`}
+        className="h-16 w-auto rounded border border-slate-200 hover:opacity-90 transition-opacity"
+      />
+    </a>
+  );
+}
+
+function ContentCell({ row }) {
+  if (row.message_type === 'image') return <ImageCell row={row} />;
+
+  if (!row.content) return <span className="text-slate-400 text-sm">—</span>;
+
+  return (
+    <span className="text-sm text-slate-700 font-mono whitespace-pre-wrap break-words max-w-xs block">
+      {row.content.length > 120 ? `${row.content.slice(0, 120)}…` : row.content}
+    </span>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="py-16 text-center">
+      <div className="w-12 h-12 rounded-xl bg-slate-100 flex items-center justify-center mx-auto mb-4">
+        <svg className="w-6 h-6 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+        </svg>
+      </div>
+      <p className="text-slate-500 text-sm">No messages in the last 5 days</p>
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="py-16 flex items-center justify-center">
+      <svg className="w-6 h-6 text-indigo-500 animate-spin" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+    </div>
+  );
+}
+
+export default function MessageLogPage() {
+  const { rows, loading, error, refresh } = useMessageLog();
+
+  const sentCount  = rows.filter(r => r.status === 'sent').length;
+  const failedCount = rows.filter(r => r.status === 'failed').length;
+  const imageCount  = rows.filter(r => r.message_type === 'image').length;
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 tracking-tight">Messages</h1>
+          <p className="text-slate-500 mt-1">Outbound WhatsApp sends — last 5 days</p>
+        </div>
+        <button
+          onClick={refresh}
+          disabled={loading}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-indigo-600 bg-indigo-50 hover:bg-indigo-100 rounded-lg transition-colors disabled:opacity-50"
+        >
+          <svg
+            className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+          </svg>
+          Refresh
+        </button>
+      </div>
+
+      {/* Error Alert */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <svg className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <div>
+              <h3 className="text-sm font-medium text-red-800">Error loading messages</h3>
+              <p className="text-sm text-red-700 mt-1">{error}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Stats Summary */}
+      {!loading && rows.length > 0 && (
+        <div className="grid grid-cols-3 gap-4">
+          <div className="bg-white rounded-xl border border-slate-200/60 shadow-sm p-4">
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wider">Total</p>
+            <p className="text-2xl font-bold text-slate-900 mt-1">{rows.length}</p>
+          </div>
+          <div className="bg-white rounded-xl border border-slate-200/60 shadow-sm p-4">
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wider">Sent</p>
+            <p className="text-2xl font-bold text-emerald-600 mt-1">{sentCount}</p>
+          </div>
+          <div className="bg-white rounded-xl border border-slate-200/60 shadow-sm p-4">
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wider">Failed</p>
+            <p className="text-2xl font-bold text-red-600 mt-1">{failedCount}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Main Content Card */}
+      <div className="bg-white rounded-xl border border-slate-200/60 shadow-sm">
+        {/* Card Header */}
+        <div className="flex items-center gap-3 px-6 py-4 border-b border-slate-200">
+          <div className="w-9 h-9 rounded-lg bg-indigo-100 flex items-center justify-center">
+            <svg className="w-5 h-5 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-slate-900">Send Log</h2>
+            {!loading && (
+              <p className="text-xs text-slate-500 mt-0.5">{imageCount} image{imageCount !== 1 ? 's' : ''}, {rows.filter(r => r.message_type === 'text').length} text message{rows.filter(r => r.message_type === 'text').length !== 1 ? 's' : ''}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Table or State */}
+        <div className="p-6">
+          {loading && <LoadingState />}
+          {!loading && rows.length === 0 && !error && <EmptyState />}
+          {!loading && rows.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200">
+                    <th className="text-left pb-3 pr-4 text-xs font-medium text-slate-500 uppercase tracking-wider">Time (PT)</th>
+                    <th className="text-left pb-3 pr-4 text-xs font-medium text-slate-500 uppercase tracking-wider">Job</th>
+                    <th className="text-left pb-3 pr-4 text-xs font-medium text-slate-500 uppercase tracking-wider">Type</th>
+                    <th className="text-left pb-3 pr-4 text-xs font-medium text-slate-500 uppercase tracking-wider">Recipient</th>
+                    <th className="text-left pb-3 pr-4 text-xs font-medium text-slate-500 uppercase tracking-wider">Content</th>
+                    <th className="text-left pb-3 pr-4 text-xs font-medium text-slate-500 uppercase tracking-wider">Status</th>
+                    <th className="text-left pb-3 text-xs font-medium text-slate-500 uppercase tracking-wider">WAMID</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {rows.map(row => (
+                    <tr key={row.id} className="hover:bg-slate-50 transition-colors">
+                      <td className="py-3 pr-4 text-slate-600 whitespace-nowrap">{formatTime(row.sent_at)}</td>
+                      <td className="py-3 pr-4 font-mono text-slate-700 whitespace-nowrap">{row.job_name}</td>
+                      <td className="py-3 pr-4 whitespace-nowrap">
+                        <Badge text={row.message_type} className={TYPE_STYLES[row.message_type] ?? TYPE_STYLES.text} />
+                      </td>
+                      <td className="py-3 pr-4 font-mono text-slate-600 whitespace-nowrap">{row.recipient}</td>
+                      <td className="py-3 pr-4 max-w-xs">
+                        <ContentCell row={row} />
+                      </td>
+                      <td className="py-3 pr-4 whitespace-nowrap">
+                        <Badge text={row.status} className={STATUS_STYLES[row.status] ?? STATUS_STYLES.sent} />
+                      </td>
+                      <td className="py-3 font-mono text-xs text-slate-400 whitespace-nowrap">
+                        {truncateWamid(row.wamid)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/025_add_message_log.sql
+++ b/supabase/migrations/025_add_message_log.sql
@@ -1,0 +1,40 @@
+-- Migration 025: Outbound message log (F-2)
+--
+-- Tracks every WhatsApp send attempt — both image and text — at the moment
+-- it leaves the app. Distinct from message_delivery_status (migration 024),
+-- which tracks Meta webhook delivery events (delivered/read/failed).
+--
+-- This table answers: "What exactly did we send, when, and to whom?"
+-- message_delivery_status answers: "Did Meta confirm it arrived?"
+--
+-- Records ALL send attempts including failures (wamid is null for failed sends).
+-- image_path stores the Supabase Storage path (including bucket prefix) for image
+-- messages so the /messages app page can render the actual PNG inline.
+--
+-- Retention: rows accumulate indefinitely; volume is low (a few per notify run).
+-- No automated TTL needed for now.
+--
+-- @requirements REQ-v5.0-F2
+
+CREATE TABLE message_log (
+  id            bigserial    PRIMARY KEY,
+  sent_at       timestamptz  NOT NULL DEFAULT now(),
+  job_name      text         NOT NULL,   -- 'notify-4am', 'notify-friday-pm', 'cron-health-check', etc.
+  message_type  text         NOT NULL,   -- 'image' | 'text'
+  recipient     text         NOT NULL,   -- masked last 4 digits (***-***-7375)
+  content       text,                   -- text body for 'text' type; null for 'image' type
+  image_path    text,                   -- Supabase Storage path for 'image' type; null for 'text' type
+  wamid         text,                   -- null if send failed (no wamid assigned by Meta)
+  status        text         NOT NULL   -- 'sent' | 'failed'
+);
+
+CREATE INDEX message_log_sent_at_idx ON message_log (sent_at DESC);
+CREATE INDEX message_log_job_name_idx ON message_log (job_name, sent_at DESC);
+
+ALTER TABLE message_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service role full access" ON message_log
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "authenticated read" ON message_log
+  FOR SELECT TO authenticated USING (true);


### PR DESCRIPTION
## Summary

- Adds `message_log` table (migration 025) — records every outbound WhatsApp send at the moment it leaves the app, including failures
- Adds `recordMessageLog` export to `src/lib/messageDeliveryStatus.js` — non-fatal, records ALL results (sent + failed), unlike `recordSentMessages` which skips failures
- Adds `storeRosterImage` private helper to `api/notify.js` — fetches the roster PNG after send and uploads to existing Supabase Storage bucket `roster-images`; non-fatal (null imagePath on failure)
- Wires all **6 send sites**: `api/notify.js` (3 call sites), `cron-health-check.js`, `integration-check.js`, `gmail-monitor.js`
- New `/messages` page with `useMessageLog` hook — last 5 days, table with status/type badges, roster PNGs rendered inline via signed URLs (1hr TTL)
- "Messages" nav item added to `Layout.jsx`

## Test plan

- [x] 15 new tests (6 `recordMessageLog` unit tests + 9 `MessageLogPage` smoke tests)
- [x] 999 tests total, 0 failures, all pre-commit hooks green
- [ ] Apply migration 025 in Supabase SQL editor
- [ ] Merge PR, confirm Vercel deploy succeeds
- [ ] Trigger a real notify run — verify row appears in `/messages` with roster image

## Key design decisions (do not revisit)

- `message_log` is separate from `message_delivery_status` — different concerns: what WE sent vs. what Meta confirmed arrived
- `image_path` stored as `roster-images/{jobName}/{timestamp}.png`; page strips the bucket prefix before calling `createSignedUrl`
- ISO timestamps in Storage paths have colons replaced with dashes (`2026-04-22T11-00-00.000Z.png`) to avoid any path-encoding issues
