### PR TITLE
fix: emit ::warning:: when integration check Step 3 is skipped (#184)

### DIFF
--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -618,6 +618,7 @@ async function main() {
     claudeNames = await extractNamesFromScreenshot(anthropic, screenshot);
   } catch (err) {
     console.error('[IntegCheck] Claude vision failed (skipping name check): %s', err.message);
+    console.log(`::warning::Integration check Step 3 (Claude vision) skipped — ${err.message}`);
   }
 
   // Step 4: DB — boarding + daytime in parallel


### PR DESCRIPTION
## Summary

Closes #184.

When `ANTHROPIC_API_KEY` has no credits, Step 3 (Claude vision name-check) is non-fatal — the check falls through and continues with `claudeNames = []`. Previously this was only visible in structured logs. This PR adds a `::warning::` annotation so the skip shows as a yellow banner in the GH Actions run summary.

## Change

`scripts/integration-check.js` — one line added to the Step 3 catch block:

```js
console.log(`::warning::Integration check Step 3 (Claude vision) skipped — ${err.message}`);
```

The existing `console.error` is preserved. No behavior change when Step 3 succeeds.

## Test plan

- [x] 999 tests, 0 failures
- [ ] Verify: trigger integration check manually via `workflow_dispatch` with no Anthropic credits → confirm yellow warning annotation appears in Actions UI
