### PR TITLE
feat: R-1 — Q Boarding 6th box in daily roster image (#186)

### DIFF
--- a/api/roster-image.js
+++ b/api/roster-image.js
@@ -292,6 +292,106 @@ function workerCard(worker, colWidth) {
 }
 
 // ---------------------------------------------------------------------------
+// Q Boarding card
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the "Q Boarding" card for the 6th slot in the daily roster grid.
+ *
+ * Shows all overnight boarders for the day (all workers combined), sorted
+ * alphabetically. Heading is Forest Green (#4A773C) to distinguish it from
+ * worker cards (which use Sage Green). No diff indicators — boarders have
+ * no yesterday baseline.
+ *
+ * Exported for unit testing.
+ *
+ * @param {string[]} boarders - Pet name strings from getPictureOfDay result
+ * @param {number} colWidth   - Pixel width of this column
+ * @returns {object}
+ */
+export function qBoardingCard(boarders, colWidth) {
+  const sorted = [...boarders].sort((a, b) =>
+    decodeEntities(a).toLowerCase().localeCompare(decodeEntities(b).toLowerCase())
+  );
+
+  console.log(`[RosterImage] Q Boarding: ${sorted.length} boarders (${sorted.join(', ') || 'none'})`);
+
+  const dogRows = sorted.length > 0
+    ? sorted.map(name =>
+        h('div', {
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          height: DOG_ROW_H,
+          paddingLeft: H_PADDING,
+          paddingRight: H_PADDING,
+        },
+          h('span', {
+            fontFamily: 'Inter',
+            fontWeight: 400,
+            fontSize: 13,
+            color: COLORS.unchanged,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }, decodeEntities(name)),
+        )
+      )
+    : [h('div', {
+        display: 'flex',
+        alignItems: 'center',
+        height: DOG_ROW_H,
+        paddingLeft: H_PADDING,
+        fontFamily: 'Inter',
+        fontWeight: 400,
+        fontSize: 13,
+        color: COLORS.dogCount,
+        fontStyle: 'italic',
+      }, '(none tonight)')];
+
+  return h('div', {
+    display: 'flex',
+    flexDirection: 'column',
+    width: colWidth,
+    backgroundColor: COLORS.workerBg,
+    border: `1px solid ${COLORS.workerBorder}`,
+    borderRadius: 8,
+    overflow: 'hidden',
+    marginBottom: ROW_GAP,
+  },
+    h('div', {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      height: WORKER_NAME_H + V_PADDING,
+      paddingLeft: H_PADDING,
+      paddingRight: H_PADDING,
+      borderBottom: `1px solid ${COLORS.workerBorder}`,
+    },
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 700,
+        fontSize: 14,
+        color: COLORS.headerBg, // Forest Green #4A773C — per spec
+        flex: 1,
+      }, 'Q Boarding'),
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 400,
+        fontSize: 12,
+        color: COLORS.dogCount,
+      }, `${sorted.length} dog${sorted.length !== 1 ? 's' : ''}`),
+    ),
+    h('div', {
+      display: 'flex',
+      flexDirection: 'column',
+      paddingTop: 6,
+      paddingBottom: 6,
+    }, ...dogRows),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Full image layout
 // ---------------------------------------------------------------------------
 
@@ -318,20 +418,31 @@ function cardHeight(worker) {
 }
 
 /**
+ * Estimate the pixel height of the Q Boarding card.
+ * Math.max(boarders.length, 1) reserves one row for the "(none tonight)" empty state.
+ *
+ * @param {string[]} boarders
+ * @returns {number}
+ */
+function qBoardingCardHeight(boarders) {
+  return WORKER_NAME_H + V_PADDING + 12 + Math.max(boarders.length, 1) * DOG_ROW_H;
+}
+
+/**
  * Compute the total image height dynamically based on content.
- * Boarders section removed in v4.1.1 — only worker cards are rendered.
+ * Treats Q Boarding as the (N+1)th slot after all worker cards.
  *
  * @param {object} data - getPictureOfDay result
  * @returns {number}
  */
-function computeImageHeight(data) {
+export function computeImageHeight(data) {
   const cols = columnsPerRow(data.workers.length);
+  const allHeights = [...data.workers.map(cardHeight), qBoardingCardHeight(data.boarders)];
   let gridH = 0;
 
-  for (let i = 0; i < data.workers.length; i += cols) {
-    const rowWorkers = data.workers.slice(i, i + cols);
-    const rowH = Math.max(...rowWorkers.map(cardHeight));
-    gridH += rowH + ROW_GAP;
+  for (let i = 0; i < allHeights.length; i += cols) {
+    const rowHeights = allHeights.slice(i, i + cols);
+    gridH += Math.max(...rowHeights) + ROW_GAP;
   }
 
   return HEADER_H + gridH + OUTER_PAD * 3;
@@ -344,8 +455,7 @@ function computeImageHeight(data) {
  *   [Header: "Thursday, March 5 (as of 6:04 PM, Mon 3/16)"  ·  Daily Roster  ·  UPDATED!]
  *   [Worker grid: N columns, each worker gets a card]
  *
- * Boarders section removed in v4.1.1 — data.boarders still exists in the
- * data struct for easy restoration, but is not rendered here.
+ * data.boarders is rendered as the "Q Boarding" 6th box (bottom-right slot).
  *
  * @param {object} data       - getPictureOfDay result
  * @param {string|null} asOfStr - Pre-formatted "as of" string (e.g. "6:04 PM, Mon 3/16"),
@@ -358,11 +468,16 @@ function buildLayout(data, asOfStr) {
   const colWidth = Math.floor((availableWidth - COL_GAP * (cols - 1)) / cols);
 
   // Worker grid — fill rows left to right.
+  // Q Boarding is appended as the (N+1)th item, placing it in the empty slot
+  // bottom-right when 5 workers are active (the typical case). With 6 workers
+  // it flows into a new third row at position col 1 — acceptable.
+  const Q_BOARDING = Symbol('qBoarding');
+  const allItems = [...data.workers, Q_BOARDING];
   const rows = [];
-  for (let i = 0; i < data.workers.length; i += cols) {
-    const rowWorkers = data.workers.slice(i, i + cols);
+  for (let i = 0; i < allItems.length; i += cols) {
+    const rowItems = allItems.slice(i, i + cols);
     // Pad short rows with null so flex layout stays consistent.
-    while (rowWorkers.length < cols) rowWorkers.push(null);
+    while (rowItems.length < cols) rowItems.push(null);
 
     rows.push(
       h('div', {
@@ -372,9 +487,11 @@ function buildLayout(data, asOfStr) {
         marginBottom: ROW_GAP,
         width: availableWidth,
       },
-        ...rowWorkers.map(w =>
-          w
-            ? workerCard(w, colWidth)
+        ...rowItems.map(item =>
+          item === Q_BOARDING
+            ? qBoardingCard(data.boarders, colWidth)
+            : item
+            ? workerCard(item, colWidth)
             : h('div', { width: colWidth, flexShrink: 0 }) // empty spacer
         ),
       )

--- a/src/__tests__/rosterImage.test.js
+++ b/src/__tests__/rosterImage.test.js
@@ -31,6 +31,8 @@ import {
   getWeekendWindowISO,
   getWeekendBoardings,
   computeWeekendImageHeight,
+  qBoardingCard,
+  computeImageHeight,
 } from '../../api/roster-image.js';
 
 // ---------------------------------------------------------------------------
@@ -273,5 +275,76 @@ describe('computeWeekendImageHeight', () => {
     const h4 = computeWeekendImageHeight([{},{},{}], [{},{}]);
     expect(h0).toBe(h1); // both render 1 placeholder row per section
     expect(h4).toBeGreaterThan(h0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// qBoardingCard
+// ---------------------------------------------------------------------------
+
+describe('qBoardingCard', () => {
+  const COL_WIDTH = 240;
+
+  it('renders heading "Q Boarding" with correct dog count', () => {
+    const card = qBoardingCard(['Mochi', 'Bronwyn', 'Tula'], COL_WIDTH);
+    const cardStr = JSON.stringify(card);
+    expect(cardStr).toContain('Q Boarding');
+    expect(cardStr).toContain('3 dogs');
+  });
+
+  it('sorts boarders alphabetically (case-insensitive)', () => {
+    const card = qBoardingCard(['Tula', 'bronwyn', 'Mochi'], COL_WIDTH);
+    const cardStr = JSON.stringify(card);
+    const bronwynIdx = cardStr.indexOf('bronwyn');
+    const mochiIdx = cardStr.indexOf('Mochi');
+    const tulaIdx = cardStr.indexOf('Tula');
+    // bronwyn < Mochi < Tula alphabetically
+    expect(bronwynIdx).toBeLessThan(mochiIdx);
+    expect(mochiIdx).toBeLessThan(tulaIdx);
+  });
+
+  it('renders "(none tonight)" when boarders list is empty', () => {
+    const card = qBoardingCard([], COL_WIDTH);
+    const cardStr = JSON.stringify(card);
+    expect(cardStr).toContain('(none tonight)');
+    expect(cardStr).toContain('0 dogs');
+  });
+
+  it('uses singular "dog" for exactly 1 boarder', () => {
+    const card = qBoardingCard(['Mochi'], COL_WIDTH);
+    expect(JSON.stringify(card)).toContain('1 dog');
+    expect(JSON.stringify(card)).not.toContain('1 dogs');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeImageHeight — includes Q Boarding slot
+// ---------------------------------------------------------------------------
+
+describe('computeImageHeight', () => {
+  function makeWorker(dogCount) {
+    return { dogs: Array(dogCount).fill({ pet_names: ['Dog'], client_name: '', series_id: null, isAdded: false, isRemoved: false }) };
+  }
+
+  it('is taller than a layout with no Q Boarding (same workers, more rows)', () => {
+    // 5 workers fills 2 rows of 3; adding Q Boarding fills the 6th slot in row 2 —
+    // same row count but the height of that row may grow if boarders list is taller.
+    // Regardless, height must be > 0.
+    const data = { workers: [makeWorker(3), makeWorker(2), makeWorker(4), makeWorker(1), makeWorker(3)], boarders: [] };
+    expect(computeImageHeight(data)).toBeGreaterThan(0);
+  });
+
+  it('grows when boarders list is longer (Q Boarding card is taller)', () => {
+    const workers = [makeWorker(1), makeWorker(1), makeWorker(1), makeWorker(1), makeWorker(1)];
+    const shortBoarders = { workers, boarders: [] };
+    const longBoarders = { workers, boarders: ['A','B','C','D','E','F','G','H','I','J'] };
+    expect(computeImageHeight(longBoarders)).toBeGreaterThan(computeImageHeight(shortBoarders));
+  });
+
+  it('empty boarders still reserves 1 row (no zero-height Q Boarding card)', () => {
+    const withZero = { workers: [makeWorker(0)], boarders: [] };
+    const withOne = { workers: [makeWorker(0)], boarders: ['Mochi'] };
+    // Both reserve 1 row in Q Boarding — height should be equal
+    expect(computeImageHeight(withZero)).toBe(computeImageHeight(withOne));
   });
 });


### PR DESCRIPTION
## Summary

- Adds "Q Boarding" card to the bottom-right empty slot in the weekday daily roster image
- Shows all overnight boarders for the day (all workers combined), sorted alphabetically
- Change isolated to `api/roster-image.js` — no DB changes, no changes to `pictureOfDay.js` or `notify.js`

## How it works

`data.boarders` already exists on the `getPictureOfDay` result (populated by `queryBoarders` in `pictureOfDay.js`). The Q Boarding card just renders it.

A `Symbol('qBoarding')` sentinel is appended to the workers array so the grid loop places the card naturally — bottom-right when 5 workers are active, new row col-1 when all 6 are active.

## Test plan

- [ ] 7 new unit tests pass (`qBoardingCard` with dogs, sort order, empty state, singular count, `computeImageHeight` grows with boarders, empty boarders reserves 1 row)
- [ ] 1006 total tests, 0 failures
- [ ] CI green
- [ ] Deploy to Vercel — trigger `notify?window=830am` manually and confirm Q Boarding box appears in the image
