### PR TITLE
fix: Q Boarding box uses boardings table for overnight list (#188)

### DIFF
--- a/src/__tests__/pictureOfDay.test.js
+++ b/src/__tests__/pictureOfDay.test.js
@@ -45,25 +45,29 @@ function appt(overrides = {}) {
 /**
  * Build a minimal Supabase mock that returns the given row arrays for each query.
  *
- * The mock intercepts .from('daytime_appointments').select(...) chains by
- * tracking the last .eq() call to determine which query is in flight.
- * Workers table returns the provided workers array.
+ * The mock routes by table name:
+ *   'workers'              → workerRows
+ *   'boardings'            → boarderRows (new: queryBoarders uses boardings table)
+ *   'daytime_appointments' → todayRows by default; yestRows when the last .eq()
+ *                            sets appointment_date to yestDateStr
  *
  * This is intentionally minimal — only the fields used by getPictureOfDay.
+ *
+ * boarderRows format: [{ booking_status: string|null, dogs: { name: string } }]
  */
 function buildSupaMock({ todayRows = [], yestRows = [], workerRows = [], boarderRows = [], yestDateStr = YEST } = {}) {
   const buildChain = (rows) => {
     const chain = {
       select: () => chain,
       eq: (col, val) => {
-        // Distinguish today vs yesterday vs boarding queries
         if (col === 'appointment_date' && val === yestDateStr) {
           chain._rows = yestRows;
-        } else if (col === 'service_category' && val === 'Boarding') {
-          chain._rows = boarderRows;
         }
         return chain;
       },
+      lt:  () => chain,
+      gte: () => chain,
+      not: () => chain,
       in: () => chain,
       order: () => chain,
       maybeSingle: async () => ({ data: null, error: null }),
@@ -85,7 +89,8 @@ function buildSupaMock({ todayRows = [], yestRows = [], workerRows = [], boarder
   return {
     from: (table) => {
       if (table === 'workers') return buildChain(workerRows);
-      // For daytime_appointments, start with todayRows as default
+      if (table === 'boardings') return buildChain(boarderRows);
+      // daytime_appointments — default to todayRows; eq() intercepts yesterday
       return buildChain(todayRows);
     },
   };
@@ -403,5 +408,53 @@ describe('getPictureOfDay diff logic', () => {
     const result = await getPictureOfDay(supa, date);
 
     expect(result.workers.every(w => w.workerId !== 0)).toBe(true);
+  });
+
+  it('boarders: returns dog names from boardings table (not daytime_appointments)', async () => {
+    const boarderRows = [
+      { booking_status: 'confirmed', dogs: { name: 'Mochi' } },
+      { booking_status: null, dogs: { name: 'Bronwyn' } },
+    ];
+    const supa = buildSupaMock({ boarderRows });
+
+    const result = await getPictureOfDay(supa, parseDateParam(DATE));
+
+    expect(result.boarders).toHaveLength(2);
+    expect(result.boarders).toContain('Mochi');
+    expect(result.boarders).toContain('Bronwyn');
+  });
+
+  it('boarders: excludes cancelled bookings', async () => {
+    const boarderRows = [
+      { booking_status: 'confirmed', dogs: { name: 'Mochi' } },
+      { booking_status: 'cancelled', dogs: { name: 'Ghost' } },
+    ];
+    const supa = buildSupaMock({ boarderRows });
+
+    const result = await getPictureOfDay(supa, parseDateParam(DATE));
+
+    expect(result.boarders).toEqual(['Mochi']);
+  });
+
+  it('boarders: deduplicates dogs that appear in multiple boarding rows', async () => {
+    // Mirrors the Annie/Tracy bug: AGYD gave two appointment IDs for the same stay,
+    // causing the sync to create two boarding rows for the same dog.
+    const boarderRows = [
+      { booking_status: 'confirmed', dogs: { name: 'Annie' } },
+      { booking_status: 'confirmed', dogs: { name: 'Annie' } }, // duplicate row
+    ];
+    const supa = buildSupaMock({ boarderRows });
+
+    const result = await getPictureOfDay(supa, parseDateParam(DATE));
+
+    expect(result.boarders).toEqual(['Annie']);
+  });
+
+  it('boarders: returns empty array when no boardings overlap', async () => {
+    const supa = buildSupaMock({ boarderRows: [] });
+
+    const result = await getPictureOfDay(supa, parseDateParam(DATE));
+
+    expect(result.boarders).toEqual([]);
   });
 });

--- a/src/lib/pictureOfDay.js
+++ b/src/lib/pictureOfDay.js
@@ -132,24 +132,42 @@ async function queryAppointmentsByDate(supabase, dateStr, label) {
 }
 
 /**
- * Query boarding dogs present on a given date.
- * Returns a deduplicated array of pet name strings.
+ * Query boarding dogs present overnight on a given date.
+ * Returns a deduplicated array of dog name strings.
+ *
+ * Uses the boardings table (source of truth for overnight stays) rather than
+ * daytime_appointments service_category='Boarding', which only captures dogs
+ * whose external appointment is typed as Boarding — missing dogs who have DC/PG
+ * daytime appointments on the same day as their overnight stay.
+ *
+ * A dog is "overnight tonight" if:
+ *   arrival_datetime  <  midnight(dateStr+1) local time  (arrived by end of today)
+ *   departure_datetime >= midnight(dateStr+1) local time  (departs tomorrow or later)
  *
  * Error-handling: returns [] on DB error (boarders list is non-critical;
  * a failed boarders query should not block the image send).
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
- * @param {string} dateStr
+ * @param {string} dateStr - YYYY-MM-DD
  * @returns {Promise<string[]>}
  */
 async function queryBoarders(supabase, dateStr) {
-  log(`Querying boarders for ${dateStr}`);
+  log(`Querying boarders for ${dateStr} (from boardings table)`);
+
+  // Midnight of dateStr+1 in local time — dogs staying overnight must depart
+  // at or after this moment. Using local Date to stay consistent with
+  // parseDateParam and the rest of the date logic in this module.
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const nextDayMidnight = new Date(y, m - 1, d + 1); // JS handles month/day overflow
+  const nextDayISO = nextDayMidnight.toISOString();
+
+  log(`Boarders date boundary: arrival < ${nextDayISO} AND departure >= ${nextDayISO}`);
 
   const { data, error } = await supabase
-    .from('daytime_appointments')
-    .select('pet_names')
-    .eq('appointment_date', dateStr)
-    .eq('service_category', 'Boarding');
+    .from('boardings')
+    .select('booking_status, dogs(name)')
+    .lt('arrival_datetime', nextDayISO)
+    .gte('departure_datetime', nextDayISO);
 
   if (error) {
     // Decision: non-fatal — return empty list and warn.
@@ -157,15 +175,16 @@ async function queryBoarders(supabase, dateStr) {
     return [];
   }
 
-  // Flatten all pet_names arrays, deduplicate preserving first-seen order.
+  // Deduplicate by name — a dog with multiple boarding rows (e.g. sync created
+  // duplicates from the same AGYD booking) should appear only once.
   const seen = new Set();
   const boarders = [];
-  for (const row of data) {
-    for (const name of (row.pet_names || [])) {
-      if (name && !seen.has(name)) {
-        seen.add(name);
-        boarders.push(name);
-      }
+  for (const row of (data || [])) {
+    if (row.booking_status === 'cancelled') continue;
+    const name = row.dogs?.name;
+    if (name && !seen.has(name)) {
+      seen.add(name);
+      boarders.push(name);
     }
   }
 


### PR DESCRIPTION
## Summary

- `queryBoarders` previously queried `daytime_appointments` with `service_category='Boarding'`, which only captured dogs whose AGYD appointment is typed Boarding
- Dogs with DC/PG daytime appointments on the same night (e.g. Annie, Tracy) had no Boarding row in `daytime_appointments` and were silently excluded from Q Boarding
- Fix: query `boardings` table directly with date-overlap filter (`arrival < midnight(dateStr+1)`, `departure >= midnight(dateStr+1)`), joining `dogs` for the name
- Deduplicate by dog name to guard against duplicate boarding rows from the same AGYD booking synced under two external IDs
- 4 new tests; 1010 total, 0 failures

## Test plan

- [ ] All 1010 tests pass (CI)
- [ ] After deploy: trigger roster image for today — confirm Annie, Tracy, and Frances all appear in Q Boarding
