### PR TITLE
feat: J-1 — intraday boarding change notification job (#190)

### DIFF
--- a/.github/workflows/notify-intraday.yml
+++ b/.github/workflows/notify-intraday.yml
@@ -1,0 +1,28 @@
+# Hourly intraday boarding change check, 9am–8pm PDT Mon–Fri.
+# DST: times are PDT (Mar–Nov). Revisit UTC offsets at each DST transition.
+# Two cron expressions are required because the 5pm–8pm PDT window spans UTC midnight:
+#   5pm–8pm PDT = 0am–3am UTC on the following calendar day.
+#   Mon–Fri PDT evenings = Tue–Sat UTC, hence days-of-week '2-6' on the second expression.
+name: Notify Intraday (9am–8pm hourly)
+
+on:
+  schedule:
+    - cron: '0 16,17,18,19,20,21,22,23 * * 1-5'  # 9am–4pm PDT (UTC 16–23, Mon–Fri UTC)
+    - cron: '0 0,1,2,3 * * 2-6'                    # 5pm–8pm PDT (UTC 0–3, Tue–Sat UTC = Mon–Fri PDT)
+  workflow_dispatch:
+
+jobs:
+  notify-intraday:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Send intraday boarding change notification if delta changed
+        run: |
+          RESPONSE=$(curl -s -o /tmp/intraday_response.json -w "%{http_code}" \
+            "${{ secrets.APP_URL }}/api/notify-intraday?token=${{ secrets.VITE_SYNC_PROXY_TOKEN }}")
+          echo "HTTP status: $RESPONSE"
+          cat /tmp/intraday_response.json
+          if [ "$RESPONSE" != "200" ]; then
+            echo "Notify-intraday endpoint returned non-200 status"
+            exit 1
+          fi

--- a/api/intraday-image.js
+++ b/api/intraday-image.js
@@ -1,0 +1,395 @@
+/**
+ * Intraday delta image generator — returns a PNG showing boarding changes since 8:30am.
+ *
+ * GET /api/intraday-image?date=YYYY-MM-DD&token=SECRET&ts=ISO
+ *
+ * Self-contained: reads the 8:30am snapshot and current boarders itself, then
+ * renders a delta image ("Q Boarding Changes") showing added and cancelled dogs.
+ * Double-querying is intentional and matches the existing system pattern (roster-image.js).
+ *
+ * Image pipeline: buildIntradayLayout → satori (JSX-like objects → SVG) →
+ * @resvg/resvg-js (SVG → PNG buffer) → HTTP response.
+ *
+ * Runs on Node.js runtime — required by @resvg/resvg-js native bindings.
+ *
+ * @requirements REQ-J1
+ */
+
+import { timingSafeEqual } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+import satori from 'satori';
+import { Resvg } from '@resvg/resvg-js';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { queryBoarders, parseDateParam } from '../src/lib/pictureOfDay.js';
+import { computeIntradayDelta } from './notify-intraday.js';
+
+export const config = { runtime: 'nodejs' };
+
+// ---------------------------------------------------------------------------
+// Module-level singletons — initialized once per Lambda warm instance.
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const __dir = dirname(__filename);
+
+const FONT_REGULAR = readFileSync(join(__dir, '_fonts/inter-400.ttf'));
+const FONT_BOLD = readFileSync(join(__dir, '_fonts/inter-700.ttf'));
+
+const FONTS = [
+  { name: 'Inter', data: FONT_REGULAR, weight: 400, style: 'normal' },
+  { name: 'Inter', data: FONT_BOLD, weight: 700, style: 'normal' },
+];
+
+// ---------------------------------------------------------------------------
+// Supabase factory
+// ---------------------------------------------------------------------------
+
+function getSupabase() {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !key) throw new Error('Supabase env vars not configured');
+  return createClient(url, key);
+}
+
+// ---------------------------------------------------------------------------
+// Layout constants (reuse values from roster-image.js)
+// ---------------------------------------------------------------------------
+
+const IMAGE_WIDTH = 800;
+const OUTER_PAD = 20;
+const HEADER_H = 64;
+const DOG_ROW_H = 24;
+const SECTION_HEADER_H = 36;
+const SECTION_GAP = 16;
+
+const COLORS = {
+  bg: '#ffffff',
+  headerBg: '#4A773C',       // Forest Green
+  headerText: '#FFFFFF',
+  sectionAdded: '#78A354',   // Sage Green — added section header
+  sectionCancelled: '#dc2626', // red-600 — cancelled section header
+  dogText: '#333333',        // Deep Charcoal
+  secondary: '#777777',      // Medium Gray
+  sectionBorder: '#d0e8c2',  // Light sage border
+};
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+function h(type, style, ...children) {
+  const flat = children.flat(Infinity).filter(c => c !== null && c !== undefined && c !== false);
+  return {
+    type,
+    props: {
+      style,
+      children: flat.length === 0 ? undefined : flat.length === 1 ? flat[0] : flat,
+    },
+  };
+}
+
+/**
+ * Format a date range for the intraday image: "Apr 29 – May 2"
+ * More readable than the compact format used in the roster image card.
+ *
+ * @param {string} arrivalIso
+ * @param {string} departureIso
+ * @returns {string}
+ */
+function formatReadableDateRange(arrivalIso, departureIso) {
+  const fmt = (iso) => {
+    if (!iso) return '?';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '?';
+    return d.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'America/Los_Angeles',
+    });
+  };
+  return `${fmt(arrivalIso)} – ${fmt(departureIso)}`; // en dash with spaces
+}
+
+/**
+ * Format a full date for the image header: "Wednesday, April 29"
+ *
+ * @param {string} dateStr - YYYY-MM-DD
+ * @returns {string}
+ */
+function formatHeaderDate(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+}
+
+/**
+ * Format the "as of" time for the header right side: "as of 2:00 PM"
+ * Returns null if no ts param was supplied.
+ *
+ * @param {string|null} isoStr
+ * @returns {string|null}
+ */
+function formatAsOfTime(isoStr) {
+  if (!isoStr) return null;
+  const d = new Date(isoStr);
+  if (isNaN(d.getTime())) return null;
+  return d.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'America/Los_Angeles',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Image layout — exported for unit testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the satori element tree for the intraday delta image.
+ *
+ * Layout:
+ *   [Forest Green header: "Q Boarding Changes · Wednesday, April 29" | "since 8:30 AM (as of 2:00 PM)"]
+ *   [✅ Added (N dog/dogs) — sage green section header]
+ *   [  Mochi Hill (Apr 29 – May 2)]
+ *   [❌ Cancelled (N dog/dogs) — red section header]
+ *   [  Tula (Apr 27 – May 1)]
+ *
+ * Exported for unit testing.
+ *
+ * @param {{ date: string, added: Array, cancelled: Array, asOfStr: string|null }} opts
+ * @returns {object} Satori element tree
+ */
+export function buildIntradayLayout({ date, added, cancelled, asOfStr }) {
+  const headerDate = formatHeaderDate(date);
+  const headerRight = asOfStr ? `since 8:30 AM (as of ${asOfStr})` : 'since 8:30 AM';
+
+  // Build a delta section (Added or Cancelled).
+  const buildSection = (emoji, label, boarders, headerColor) => {
+    const count = boarders.length;
+    const sectionLabel = `${emoji} ${label} (${count} ${count === 1 ? 'dog' : 'dogs'})`;
+
+    const rows = boarders.map(b =>
+      h('div', {
+        display: 'flex',
+        alignItems: 'center',
+        height: DOG_ROW_H,
+        paddingLeft: OUTER_PAD,
+        paddingRight: OUTER_PAD,
+      },
+        h('span', {
+          fontFamily: 'Inter',
+          fontWeight: 400,
+          fontSize: 13,
+          color: COLORS.dogText,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }, `${b.name} (${formatReadableDateRange(b.arrival_datetime, b.departure_datetime)})`),
+      )
+    );
+
+    return h('div', {
+      display: 'flex',
+      flexDirection: 'column',
+      marginBottom: SECTION_GAP,
+    },
+      // Section header
+      h('div', {
+        display: 'flex',
+        alignItems: 'center',
+        height: SECTION_HEADER_H,
+        paddingLeft: OUTER_PAD,
+        paddingRight: OUTER_PAD,
+        backgroundColor: headerColor,
+        borderRadius: 4,
+        marginBottom: 4,
+      },
+        h('span', {
+          fontFamily: 'Inter',
+          fontWeight: 700,
+          fontSize: 14,
+          color: '#ffffff',
+        }, sectionLabel),
+      ),
+      // Dog rows
+      h('div', {
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: COLORS.bg,
+        border: `1px solid ${COLORS.sectionBorder}`,
+        borderRadius: 4,
+      }, ...rows),
+    );
+  };
+
+  const sections = [];
+  if (added.length > 0) {
+    sections.push(buildSection('✅', 'Added', added, COLORS.sectionAdded));
+  }
+  if (cancelled.length > 0) {
+    sections.push(buildSection('❌', 'Cancelled', cancelled, COLORS.sectionCancelled));
+  }
+
+  return h('div', {
+    display: 'flex',
+    flexDirection: 'column',
+    width: IMAGE_WIDTH,
+    backgroundColor: COLORS.bg,
+    fontFamily: 'Inter',
+  },
+    // Header bar
+    h('div', {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      width: IMAGE_WIDTH,
+      height: HEADER_H,
+      backgroundColor: COLORS.headerBg,
+      paddingLeft: OUTER_PAD,
+      paddingRight: OUTER_PAD,
+    },
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 700,
+        fontSize: 18,
+        color: COLORS.headerText,
+        flex: 1,
+      }, `Q Boarding Changes · ${headerDate}`),
+      h('span', {
+        fontFamily: 'Inter',
+        fontWeight: 400,
+        fontSize: 13,
+        color: '#94a3b8', // slate-400
+      }, headerRight),
+    ),
+
+    // Content area
+    h('div', {
+      display: 'flex',
+      flexDirection: 'column',
+      padding: OUTER_PAD,
+    }, ...sections),
+  );
+}
+
+/**
+ * Compute the total image height for the intraday layout.
+ * Exported for unit testing.
+ *
+ * @param {{ added: Array, cancelled: Array }} delta
+ * @returns {number}
+ */
+export function computeIntradayImageHeight({ added, cancelled }) {
+  const sectionH = (count) =>
+    count > 0 ? SECTION_HEADER_H + 4 + count * DOG_ROW_H + SECTION_GAP : 0;
+  return HEADER_H + OUTER_PAD * 2 + sectionH(added.length) + sectionH(cancelled.length);
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot reader (duplicated from notify-intraday.js — intentional per plan)
+// ---------------------------------------------------------------------------
+
+async function readBoardersSnapshot(supabase, todayStr) {
+  const { data, error } = await supabase
+    .from('cron_health')
+    .select('result')
+    .eq('cron_name', 'boarders-snapshot')
+    .maybeSingle();
+
+  if (error) {
+    console.warn(`[IntradayImage] Could not read boarders snapshot: ${error.message}`);
+    return null;
+  }
+
+  if (!data?.result) return null;
+
+  if (data.result.snapshotDate !== todayStr) {
+    console.log(`[IntradayImage] Snapshot date mismatch: found ${data.result.snapshotDate}, today is ${todayStr}`);
+    return null;
+  }
+
+  return data.result;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler
+// ---------------------------------------------------------------------------
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Token auth — timingSafeEqual prevents timing attacks.
+  const providedToken = req.query.token ?? '';
+  const expectedToken = process.env.VITE_SYNC_PROXY_TOKEN ?? '';
+  const tokenValid =
+    expectedToken.length > 0 &&
+    providedToken.length === expectedToken.length &&
+    timingSafeEqual(Buffer.from(providedToken), Buffer.from(expectedToken));
+  if (!tokenValid) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  // Parse date param
+  let date;
+  try {
+    date = parseDateParam(req.query.date || '');
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+  const dateStr = [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
+
+  const tsParam = req.query.ts || null;
+  const asOfStr = formatAsOfTime(tsParam);
+
+  console.log(`[IntradayImage] Generating delta image for ${dateStr}, as-of: "${asOfStr ?? 'none'}"`);
+
+  try {
+    const supabase = getSupabase();
+
+    // Read snapshot
+    const snapshot = await readBoardersSnapshot(supabase, dateStr);
+    const snapshotBoarders = snapshot?.boarders ?? [];
+    if (!snapshot) {
+      console.log(`[IntradayImage] No snapshot for ${dateStr} — rendering empty delta`);
+    }
+
+    // Query current boarders
+    const currentBoarders = await queryBoarders(supabase, dateStr);
+    console.log(`[IntradayImage] Snapshot: ${snapshotBoarders.length} boarders. Current: ${currentBoarders.length} boarders`);
+
+    // Compute delta
+    const { added, cancelled } = computeIntradayDelta(snapshotBoarders, currentBoarders);
+    console.log(`[IntradayImage] Delta: ${added.length} added, ${cancelled.length} cancelled`);
+
+    const element = buildIntradayLayout({ date: dateStr, added, cancelled, asOfStr });
+    const height = computeIntradayImageHeight({ added, cancelled });
+    // Ensure a minimum height even when delta is empty (caller shouldn't render this,
+    // but defensive guard so satori doesn't get height=0).
+    const safeHeight = Math.max(height, HEADER_H + OUTER_PAD * 2);
+    console.log(`[IntradayImage] Computed dimensions: ${IMAGE_WIDTH}x${safeHeight}`);
+
+    const svg = await satori(element, { width: IMAGE_WIDTH, height: safeHeight, fonts: FONTS });
+    const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: IMAGE_WIDTH } });
+    const pngBuffer = resvg.render().asPng();
+
+    console.log(`[IntradayImage] PNG generated — ${pngBuffer.length} bytes`);
+
+    res.setHeader('Content-Type', 'image/png');
+    res.setHeader('Content-Length', pngBuffer.length);
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    return res.status(200).send(pngBuffer);
+
+  } catch (err) {
+    console.error('[IntradayImage] ❌ Error:', err.message, err.stack);
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/api/notify-intraday.js
+++ b/api/notify-intraday.js
@@ -1,0 +1,286 @@
+/**
+ * Intraday boarding change notification — sends a delta WhatsApp image when
+ * overnight boarders tonight have changed since the 8:30am baseline.
+ *
+ * GET /api/notify-intraday?token=SECRET
+ *
+ * Called by a GitHub Actions workflow hourly from 9am–8pm PDT Mon–Fri.
+ * Skip logic (no send):
+ *   - No 8:30am snapshot for today
+ *   - Delta is empty (no changes since 8:30am)
+ *   - Delta hash matches last intraday send (nothing new since last hourly send)
+ *
+ * State: cron_health rows
+ *   'boarders-snapshot'  — written by notify.js at 8:30am; read here
+ *   'notify-intraday'    — written here after each send; read for delta hash gate
+ *
+ * @requirements REQ-J1
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { queryBoarders } from '../src/lib/pictureOfDay.js';
+import {
+  sendRosterImage,
+  getRecipients,
+} from '../src/lib/notifyWhatsApp.js';
+import { recordSentMessages, recordMessageLog } from '../src/lib/messageDeliveryStatus.js';
+import { writeCronHealth } from './_cronHealth.js';
+
+export const config = { runtime: 'nodejs' };
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for unit testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the intraday delta between the 8:30am snapshot and current boarders.
+ * Added = in current but not in snapshot. Cancelled = in snapshot but not in current.
+ * Comparison is by name — the stable identifier across boarding rows.
+ *
+ * @param {Array<{name: string, arrival_datetime: string, departure_datetime: string}>} snapshotBoarders
+ * @param {Array<{name: string, arrival_datetime: string, departure_datetime: string}>} currentBoarders
+ * @returns {{ added: typeof snapshotBoarders, cancelled: typeof snapshotBoarders }}
+ */
+export function computeIntradayDelta(snapshotBoarders, currentBoarders) {
+  const snapshotNames = new Set(snapshotBoarders.map(b => b.name));
+  const currentNames = new Set(currentBoarders.map(b => b.name));
+  const added = currentBoarders.filter(b => !snapshotNames.has(b.name));
+  const cancelled = snapshotBoarders.filter(b => !currentNames.has(b.name));
+  return { added, cancelled };
+}
+
+/**
+ * Compute a stable hash of a delta for send-gate comparison.
+ * djb2 over sorted names — avoids resending when nothing new changed since the
+ * last hourly send even though the cumulative delta remains non-empty.
+ *
+ * @param {Array} added
+ * @param {Array} cancelled
+ * @returns {string}
+ */
+export function hashDelta(added, cancelled) {
+  const key = JSON.stringify({
+    added: added.map(b => b.name).sort(),
+    cancelled: cancelled.map(b => b.name).sort(),
+  });
+  let hash = 5381;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash) ^ key.charCodeAt(i);
+    hash |= 0;
+  }
+  return String(hash >>> 0);
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+function getSupabase() {
+  const url = process.env.VITE_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !key) throw new Error('Supabase env vars not configured');
+  return createClient(url, key);
+}
+
+/**
+ * Read the 8:30am boarders snapshot from cron_health.
+ * Returns null if no snapshot row exists or the snapshot is for a different date
+ * (stale row from a prior day must not be used as today's baseline).
+ *
+ * Error-handling: returns null on DB error so the caller can skip with reason 'no_snapshot'.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} todayStr - YYYY-MM-DD
+ * @returns {Promise<{snapshotDate: string, boarders: Array, capturedAt: string}|null>}
+ */
+async function readBoardersSnapshot(supabase, todayStr) {
+  const { data, error } = await supabase
+    .from('cron_health')
+    .select('result')
+    .eq('cron_name', 'boarders-snapshot')
+    .maybeSingle();
+
+  if (error) {
+    console.warn(`[NotifyIntraday] Could not read boarders snapshot: ${error.message}`);
+    return null;
+  }
+
+  if (!data?.result) return null;
+
+  if (data.result.snapshotDate !== todayStr) {
+    console.log(`[NotifyIntraday] Snapshot date mismatch: found ${data.result.snapshotDate}, today is ${todayStr} — treating as no snapshot`);
+    return null;
+  }
+
+  return data.result;
+}
+
+/**
+ * Read the last intraday send state from cron_health.
+ * Returns { lastDeltaHash, lastDate } or null if no prior send today.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<{lastDeltaHash: string, lastDate: string}|null>}
+ */
+async function readLastIntradayState(supabase) {
+  const { data, error } = await supabase
+    .from('cron_health')
+    .select('result')
+    .eq('cron_name', 'notify-intraday')
+    .maybeSingle();
+
+  if (error) {
+    console.warn(`[NotifyIntraday] Could not read last intraday state: ${error.message} — proceeding without baseline`);
+    return null;
+  }
+
+  if (!data?.result?.lastDeltaHash) return null;
+
+  return {
+    lastDeltaHash: data.result.lastDeltaHash,
+    lastDate: data.result.lastDate || '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler
+// ---------------------------------------------------------------------------
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const providedToken = req.query.token || '';
+  const expectedToken = process.env.VITE_SYNC_PROXY_TOKEN || '';
+  if (!expectedToken || providedToken !== expectedToken) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const jobRunAt = new Date().toISOString();
+
+  // Compute today's date in Pacific time — same pattern as notify.js.
+  const todayStr = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+  }).format(new Date());
+
+  console.log(`[NotifyIntraday] Entry — date: ${todayStr}, run at: ${jobRunAt}`);
+
+  try {
+    const supabase = getSupabase();
+
+    // --- Load 8:30am snapshot ---
+    const snapshot = await readBoardersSnapshot(supabase, todayStr);
+    if (!snapshot) {
+      console.log(`[NotifyIntraday] No snapshot for today (${todayStr}) — skipping`);
+      return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_snapshot' });
+    }
+    console.log(`[NotifyIntraday] Snapshot loaded for ${todayStr} — ${snapshot.boarders.length} boarders at 8:30am: [${snapshot.boarders.map(b => b.name).join(', ')}]`);
+
+    // --- Query current boarders ---
+    const currentBoarders = await queryBoarders(supabase, todayStr);
+    console.log(`[NotifyIntraday] Current boarders: ${currentBoarders.length} — [${currentBoarders.map(b => b.name).join(', ')}]`);
+
+    // --- Compute delta ---
+    const { added, cancelled } = computeIntradayDelta(snapshot.boarders, currentBoarders);
+    console.log(`[NotifyIntraday] Delta: ${added.length} added [${added.map(b => b.name).join(', ')}], ${cancelled.length} cancelled [${cancelled.map(b => b.name).join(', ')}]`);
+
+    // --- Hash gate: skip if delta unchanged since last hourly send ---
+    const deltaHash = hashDelta(added, cancelled);
+    const lastState = await readLastIntradayState(supabase);
+    console.log(`[NotifyIntraday] Delta hash: ${deltaHash}. Last state: ${lastState ? `hash ${lastState.lastDeltaHash} on ${lastState.lastDate}` : 'none'}`);
+
+    if (lastState?.lastDate === todayStr && lastState.lastDeltaHash === deltaHash) {
+      console.log(`[NotifyIntraday] Delta hash unchanged since last send (${deltaHash}) — skipping`);
+      return res.status(200).json({ ok: true, action: 'skipped', reason: 'delta_unchanged' });
+    }
+
+    // --- Empty delta gate: skip if nothing changed since 8:30am ---
+    if (added.length === 0 && cancelled.length === 0) {
+      console.log(`[NotifyIntraday] Delta empty (no changes since 8:30am) — skipping`);
+      return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_change_since_830am' });
+    }
+
+    // --- Construct intraday image URL ---
+    const protocol = req.headers['x-forwarded-proto'] || 'https';
+    const host = req.headers['x-forwarded-host'] || req.headers.host;
+    const imageUrl = `${protocol}://${host}/api/intraday-image?date=${todayStr}&token=${expectedToken}&ts=${encodeURIComponent(jobRunAt)}`;
+    console.log(`[NotifyIntraday] Image URL: ${protocol}://${host}/api/intraday-image?date=${todayStr}&token=***&ts=${encodeURIComponent(jobRunAt)}`);
+
+    // --- Get recipients ---
+    const recipients = getRecipients();
+    if (recipients.length === 0) {
+      console.warn('[NotifyIntraday] NOTIFY_RECIPIENTS not configured — send skipped');
+      return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_recipients' });
+    }
+
+    // --- Send ---
+    console.log(`[NotifyIntraday] Sending to ${recipients.length} recipient(s) — added: ${added.length}, cancelled: ${cancelled.length}`);
+    const sendResults = await sendRosterImage(imageUrl, recipients);
+
+    // --- Record delivery observability (non-fatal) ---
+    await recordSentMessages(supabase, sendResults, 'notify-intraday').catch(err =>
+      console.warn(`[NotifyIntraday] Failed to record delivery status: ${err.message}`)
+    );
+
+    // --- Store intraday image + record message log (non-fatal) ---
+    // Reuse storeRosterImage pattern: fetch the PNG and upload to Supabase Storage.
+    let imagePath = null;
+    try {
+      const imgResp = await fetch(imageUrl);
+      if (imgResp.ok) {
+        const buf = Buffer.from(await imgResp.arrayBuffer());
+        const safeTs = jobRunAt.replace(/:/g, '-');
+        const pathInBucket = `notify-intraday/${safeTs}.png`;
+        const { error: uploadErr } = await supabase.storage
+          .from('roster-images')
+          .upload(pathInBucket, buf, { contentType: 'image/png', upsert: true });
+        if (!uploadErr) {
+          imagePath = `roster-images/${pathInBucket}`;
+          console.log(`[NotifyIntraday] Image stored at ${imagePath}`);
+        } else {
+          console.warn(`[NotifyIntraday] Image upload failed: ${uploadErr.message}`);
+        }
+      } else {
+        console.warn(`[NotifyIntraday] Image fetch failed (HTTP ${imgResp.status})`);
+      }
+    } catch (err) {
+      console.warn(`[NotifyIntraday] Image store error: ${err.message}`);
+    }
+
+    await recordMessageLog(supabase, sendResults, 'notify-intraday', 'image', null, imagePath).catch(err =>
+      console.warn(`[NotifyIntraday] Failed to record message_log: ${err.message}`)
+    );
+
+    // --- Persist intraday state ---
+    await writeCronHealth(supabase, 'notify-intraday', 'success', {
+      lastDeltaHash: deltaHash,
+      lastDate: todayStr,
+      sentAt: new Date().toISOString(),
+      addedCount: added.length,
+      cancelledCount: cancelled.length,
+      recipients: sendResults.map(r => r.to),
+    }, null);
+
+    const sentCount = sendResults.filter(r => r.status === 'sent').length;
+    const failedCount = sendResults.filter(r => r.status === 'failed').length;
+    console.log(`[NotifyIntraday] Complete — ${sentCount} sent, ${failedCount} failed. Added: ${added.length}, Cancelled: ${cancelled.length}`);
+
+    return res.status(200).json({
+      ok: true,
+      action: 'sent',
+      addedCount: added.length,
+      cancelledCount: cancelled.length,
+      sentCount,
+      failedCount,
+    });
+
+  } catch (err) {
+    console.error('[NotifyIntraday] ❌ Unhandled error:', err.message, err.stack);
+    try {
+      const supabase = getSupabase();
+      await writeCronHealth(supabase, 'notify-intraday', 'failure', null, err.message.slice(0, 500));
+    } catch { /* ignore — health write failure should not mask the original error */ }
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/api/notify.js
+++ b/api/notify.js
@@ -202,6 +202,34 @@ async function readLastSentState(supabase) {
 }
 
 /**
+ * Store the 8:30am boarders snapshot in cron_health under 'boarders-snapshot'.
+ * The hourly intraday job reads this to compute additions/cancellations since 8:30am.
+ * Stored regardless of whether the 8:30am notify actually sends — the snapshot is
+ * always captured so the hourly job has a baseline even on no-change days.
+ *
+ * Non-fatal — a failed write logs a warning but does not block the notify send.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Array<{name: string, arrival_datetime: string, departure_datetime: string}>} boarders
+ * @param {string} dateStr - YYYY-MM-DD
+ */
+async function storeBoardersSnapshot(supabase, boarders, dateStr) {
+  const snapshot = boarders.map(b => ({
+    name: b.name,
+    arrival_datetime: b.arrival_datetime,
+    departure_datetime: b.departure_datetime,
+  }));
+  await writeCronHealth(supabase, 'boarders-snapshot', 'success', {
+    snapshotDate: dateStr,
+    boarders: snapshot,
+    capturedAt: new Date().toISOString(),
+  }, null).catch(err =>
+    console.warn(`[Notify/Snapshot] Failed to store boarders snapshot: ${err.message}`)
+  );
+  console.log(`[Notify/Snapshot] Stored boarders snapshot for ${dateStr} — ${snapshot.length} boarders: [${snapshot.map(b => b.name).join(', ')}]`);
+}
+
+/**
  * Persist the just-sent hash so future sends in the same day can compare.
  * Non-fatal — a failed write doesn't block the caller.
  *
@@ -354,6 +382,13 @@ export default async function handler(req, res) {
     if (data.workers.length === 0) {
       console.warn(`[Notify] No worker data for today — skipping send (refreshed=${refresh.refreshed}, rowCount=${refresh.rowCount})`);
       return res.status(200).json({ ok: true, action: 'skipped', reason: 'no_data' });
+    }
+
+    // --- Store 8:30am boarders snapshot (J-1 baseline) ---
+    // Stored before the send-gate check so the hourly intraday job always has a baseline,
+    // even when 8:30am skips sending due to no change in the roster.
+    if (window === '8:30am') {
+      await storeBoardersSnapshot(supabase, data.boarders, dateStr);
     }
 
     // --- Read last sent state (for 7am/8:30am gate) ---

--- a/api/roster-image.js
+++ b/api/roster-image.js
@@ -296,6 +296,28 @@ function workerCard(worker, colWidth) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Format a compact date range for the Q Boarding card: "4/29–5/2"
+ * Uses America/Los_Angeles to match the rest of the app's date display.
+ *
+ * @param {string} arrivalIso
+ * @param {string} departureIso
+ * @returns {string}
+ */
+function formatCompactDateRange(arrivalIso, departureIso) {
+  const fmt = (iso) => {
+    if (!iso) return '?';
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '?';
+    return d.toLocaleDateString('en-US', {
+      month: 'numeric',
+      day: 'numeric',
+      timeZone: 'America/Los_Angeles',
+    });
+  };
+  return `${fmt(arrivalIso)}–${fmt(departureIso)}`; // en dash
+}
+
+/**
  * Render the "Q Boarding" card for the 6th slot in the daily roster grid.
  *
  * Shows all overnight boarders for the day (all workers combined), sorted
@@ -305,20 +327,21 @@ function workerCard(worker, colWidth) {
  *
  * Exported for unit testing.
  *
- * @param {string[]} boarders - Pet name strings from getPictureOfDay result
+ * @param {Array<{name: string, arrival_datetime: string, departure_datetime: string}>} boarders
  * @param {number} colWidth   - Pixel width of this column
  * @returns {object}
  */
 export function qBoardingCard(boarders, colWidth) {
   const sorted = [...boarders].sort((a, b) =>
-    decodeEntities(a).toLowerCase().localeCompare(decodeEntities(b).toLowerCase())
+    decodeEntities(a.name).toLowerCase().localeCompare(decodeEntities(b.name).toLowerCase())
   );
 
-  console.log(`[RosterImage] Q Boarding: ${sorted.length} boarders (${sorted.join(', ') || 'none'})`);
+  console.log(`[RosterImage] Q Boarding: ${sorted.length} boarders (${sorted.map(b => b.name).join(', ') || 'none'})`);
 
   const dogRows = sorted.length > 0
-    ? sorted.map(name =>
-        h('div', {
+    ? sorted.map(boarding => {
+        const label = `${decodeEntities(boarding.name)} (${formatCompactDateRange(boarding.arrival_datetime, boarding.departure_datetime)})`;
+        return h('div', {
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',
@@ -334,9 +357,9 @@ export function qBoardingCard(boarders, colWidth) {
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
-          }, decodeEntities(name)),
-        )
-      )
+          }, label),
+        );
+      })
     : [h('div', {
         display: 'flex',
         alignItems: 'center',

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,30 +1,45 @@
 # Dog Boarding App — Session Handoff (v6 — OPEN)
-**Last updated:** April 29, 2026 (session 18) — R-1 complete. J-1 is next.
+**Last updated:** May 1, 2026 (session 20) — J-1 built, PR open, pending CI + merge.
 
 ---
 
 ## Current State
 
 - **v6 OPEN** — theme: *Client-driven operational intelligence*
-- **1006 tests, 57 files, 0 failures**
-- **main clean** (PR #187 merged this session — R-1 Q Boarding box)
+- **1028 tests, 59 files, 0 failures**
+- **J-1 PR open** — pending CI + merge
 - Live at [qboarding.vercel.app](https://qboarding.vercel.app)
 
-### Session 18 Summary
+### Session 20 Summary
+| Item | Status |
+|---|---|
+| J-1 — intraday boarding change notification job | ✅ Built — PR open, issue #190 |
+
+**J-1 changes:**
+- `queryBoarders` now returns `{ name, arrival_datetime, departure_datetime }[]` (was `string[]`)
+- `hashPicture` now includes boarders in hash (boarders are rendered in Q Boarding box — R-1/PR #187)
+- Q Boarding card in roster image shows compact date ranges: `Name (M/D–M/D)`
+- `notify.js` 8:30am window stores `boarders-snapshot` in `cron_health` before the send-gate check
+- New `api/notify-intraday.js` — hourly delta handler: snapshot → current → delta → hash gate → send
+- New `api/intraday-image.js` — delta PNG: "Q Boarding Changes" header + Added/Cancelled sections
+- New `.github/workflows/notify-intraday.yml` — hourly 9am–8pm PDT Mon–Fri (two cron expressions for midnight-spanning window)
+- 18 new tests (8 notify-intraday, 5 intraday-image, 3 hash, 1 boarder object, 1 date-range render)
+
+### Session 19 Summary (reference)
+| Item | Status |
+|---|---|
+| R-1 bug fix — Q Boarding missing dogs with DC/PG appointments | ✅ PR #189 merged — issue #188 |
+| Calendar duplication (Annie/Tracy shown twice) | ✅ Root cause confirmed, data cleanup deferred |
+
+**R-1 bug fix (PR #189):** `queryBoarders` in `src/lib/pictureOfDay.js` was reading `daytime_appointments` with `service_category='Boarding'`. Dogs who have DC/PG daytime appointments on the same night (Annie, Tracy) had no Boarding row in `daytime_appointments` — invisible to Q Boarding. Fixed to query the `boardings` table directly with a date-overlap filter (`arrival < midnight(dateStr+1)`, `departure >= midnight(dateStr+1)`), joining `dogs` for names. Deduplication by name guards against the sync duplicate issue below. 4 new tests.
+
+**Calendar duplication (Annie + Tracy shown twice):** AGYD has two separate appointment IDs (`C63QgeoP` and `C63QgeoR`) for the same boarding stay (Apr 27–May 1). The sync correctly processed both distinct IDs, creating 4 boarding rows instead of 2. Likely cause: booking was modified (originally Apr 27 start, extended to Apr 26/27) creating a new AGYD record while the old one remained. **Deferred data cleanup:** delete boarding rows `d47115e8` (Annie) and `36e76c49` (Tracy) — the `C63QgeoP` pair. Null `sync_appointments.mapped_boarding_id` first (FK constraint, same pattern as the delete flow in `useBoardings.js`).
+
+### Session 18 Summary (reference)
 | Item | Status |
 |---|---|
 | R-1 — Q Boarding 6th box | ✅ PR #187 merged — issue #186 |
-| Verify on live image | ⏳ **Kate to trigger manually** — see command below |
-
-**Manual verify command (run after Vercel deploys):**
-```
-curl -s "https://qboarding.vercel.app/api/notify?window=830am&token=$VITE_SYNC_PROXY_TOKEN" | jq .
-```
-Or open the image URL directly:
-```
-https://qboarding.vercel.app/api/roster-image?date=YYYY-MM-DD&token=TOKEN
-```
-Confirm Q Boarding box appears bottom-right with correct boarder list.
+| Verify on live image | ✅ Verified April 30 — box renders. Bug found and fixed this session. |
 
 ---
 
@@ -36,68 +51,38 @@ Confirm Q Boarding box appears bottom-right with correct boarder list.
 
 **Key facts:**
 - The data already flows through the notify pipeline — boardings are queried in `getPictureOfDay()`. The 6th box just aggregates them.
-- Change is isolated to `api/roster-image.js` (Satori layout).
+- Change is isolated to `api/roster-image.js` (Satori layout) and `src/lib/pictureOfDay.js` (query source).
 - No DB change, no new cron.
 
-**Files to read before coding:**
-- `api/roster-image.js` — full layout, box rendering, data shape passed in
-- `src/lib/pictureOfDay.js` — what data is returned and how boardings are structured
-- `api/notify.js` — what gets passed to the image URL
-
 **Definition of Done:**
-- [ ] 6th box renders in existing empty slot (bottom-right)
-- [ ] Heading: "Q Boarding" in AGYD forest green `#4A773C`
+- [x] 6th box renders in existing empty slot (bottom-right)
+- [x] Heading: "Q Boarding" in AGYD forest green `#4A773C`
 - [x] Lists all dogs boarding tonight (all workers combined, sorted alphabetically)
-- [x] Dog count shown (e.g., "14 dogs") consistent with other boxes
+- [x] Dog count shown (e.g., "1 dog") consistent with other boxes
 - [x] No layout regression on the other 5 boxes (weekend path untouched)
 - [x] Unit tests: 7 new (sort order, empty state, singular/plural, height calc)
-- [x] 1006 tests pass
-- [ ] **Verify on live image** — Kate to trigger manually after deploy
+- [x] Bug fix: `queryBoarders` uses `boardings` table (not `daytime_appointments`) — PR #189
+- [x] 1010 tests pass
+- [x] Verified on live image April 30
 
 ---
 
-### J-1 — Intraday change notification job
+### J-1 — Intraday change notification job ✅ PR OPEN
 
-**What:** A new hourly job that runs 9am–8pm and sends a WhatsApp notification **only when something changed** from the 8:30am baseline. Different image design from the roster — delta-only format showing what was added or cancelled since 8:30am. Primary signal: new overnight boarders tonight. Secondary: cancellations.
-
-**Confirmed design decisions:**
-- **Baseline:** 8:30am snapshot (stored at end of the 8:30am notify run)
-- **Delta logic:** cumulative since 8:30am. Once dogA shows as new, it stays in every report until the next morning resets the baseline. No send if zero changes since 8:30am.
-- **Scope:** additions (new overnight boarders) AND cancellations (dogs removed from tonight since 8:30am)
-- **Last run:** 8pm
-- **Image design:** NOT a full worker roster grid. Delta-only format, e.g.:
-  ```
-  Changes since 8:30am, Wed 4/29
-  ✅ Added: Mochi Hill, Bronwyn
-  ❌ Cancelled: Tula
-  ```
-- **No send if no changes** — this is not a "heartbeat" job
-
-**State design (the hard part):**
-- The 8:30am notify run must store a snapshot of tonight's boarders (not just the hash) in `cron_health`.
-- The hourly job loads that snapshot and compares to the current boarders list.
-- Delta = dogs in current but not in snapshot (added) + dogs in snapshot but not in current (cancelled).
-- If delta is empty → no send. If non-empty → send delta image.
-
-**N-1 still relevant?** Yes — N-1 (blue overlay on existing morning images for intra-day changes) and J-1 (separate hourly delta job) solve different UX needs and are complementary. N-1 is still on backlog.
-
-**Files to read before coding:**
-- `api/notify.js` — where the 8:30am snapshot must be stored; how `cron_health` is written
-- `src/lib/pictureOfDay.js` — boarding data shape
-- `api/roster-image.js` — for the new delta image design
-- `.github/workflows/notify-830am.yml` — GH Actions cron pattern to copy for J-1
+**Issue:** #190 | **PR:** pending CI
 
 **Definition of Done:**
-- [ ] New GH Actions workflow: hourly 9am–8pm (Mon–Fri), `workflow_dispatch` for manual test
-- [ ] 8:30am notify run stores a `boarders_snapshot` (array of boarding IDs/names) to `cron_health`
-- [ ] Hourly job: load snapshot → compare to current → compute delta
-- [ ] No send if delta empty
-- [ ] WhatsApp message sent for non-empty delta (additions + cancellations)
-- [ ] New image design for delta-only content (distinct from full roster image)
-- [ ] Graceful fallback: if no snapshot found for today (8:30am run was skipped), log + skip send
-- [ ] Unit tests: (a) empty delta → no send, (b) addition detected → send, (c) cancellation detected → send, (d) missing snapshot → graceful skip
-- [ ] 999+ tests pass
-- [ ] Verify on a real morning cycle
+- [x] New GH Actions workflow: hourly 9am–8pm (Mon–Fri), `workflow_dispatch` for manual test
+- [x] 8:30am notify run stores `boarders-snapshot` in `cron_health`
+- [x] Hourly job: load snapshot → compare → compute delta → hash gate → send if new delta
+- [x] No send if delta empty
+- [x] WhatsApp sent for non-empty delta with "Q Boarding Changes" image
+- [x] Intraday image shows readable dates `Name (Apr 29 – May 2)`
+- [x] Q Boarding box in roster image shows compact dates `Name (M/D–M/D)`
+- [x] `hashPicture` includes boarders (boarders now rendered — R-1/PR #187)
+- [x] Graceful skip if no snapshot found for today
+- [x] 1028 tests pass, 0 failures
+- [ ] Verify on a real morning cycle (after merge)
 
 ---
 
@@ -145,10 +130,18 @@ Confirm Q Boarding box appears bottom-right with correct boarder list.
 
 ---
 
+## Known Data Issues (Deferred)
+
+| Issue | Detail | Fix when ready |
+|---|---|---|
+| Annie + Tracy duplicate boardings | AGYD created 2 appointment IDs for same stay. 4 rows in `boardings` instead of 2. Calendar shows each dog twice. | Delete rows `d47115e8` (Annie) and `36e76c49` (Tracy). Null `sync_appointments.mapped_boarding_id` first. |
+
+---
+
 ## v6 Sprint Order (Recommended)
 
-1. **R-1** — Isolated, no new infrastructure, high visual value. First win.
-2. **J-1** — New cron + state design. Architect carefully before building.
+1. **R-1** ✅ DONE — PR #187 + bug fix PR #189
+2. **J-1** — New cron + state design. Architect carefully before building. **NEXT.**
 3. **P-1** — DB schema change. Needs spec review at architect step.
 
 ---
@@ -193,7 +186,7 @@ cron-detail-2.js (00:15)    → re-exports cron-detail (second Vercel path = dou
 | `api/webhooks/meta.js` | Incoming Meta webhook — HMAC-SHA256 verify, stores delivery events |
 | `scripts/integration-check.js` | Integration check — Playwright + Claude vision + DB compare; smart-send logic |
 | `src/lib/scraper/syncRunner.js` | `runScheduleSync`, `runDetailSync` — shared sync logic |
-| `src/lib/pictureOfDay.js` | `getPictureOfDay`, `computeWorkerDiff`, `hashPicture` |
+| `src/lib/pictureOfDay.js` | `getPictureOfDay`, `computeWorkerDiff`, `hashPicture`; `queryBoarders` uses `boardings` table |
 | `api/roster-image.js` | Token-gated PNG endpoint; `formatAsOf`; `timingSafeEqual` auth; weekend path |
 | `api/notify.js` | Notify orchestrator (4am/7am/830am/friday-pm windows) + `storeRosterImage` |
 | `src/lib/notifyHelpers.js` | `refreshDaytimeSchedule` (extracted for testability) |
@@ -213,7 +206,7 @@ cron-detail-2.js (00:15)    → re-exports cron-detail (second Vercel path = dou
 | Stephen Muro | 164375 |
 
 ### GitHub Releases
-v1.0, v1.2.0, v2.0.0, v3.0.0, v3.1.0, v3.2.0, v4.0.0, v4.1.0, v4.1.1, v4.1.2, v4.2.0, v4.3.0, v4.4.0, v4.4.1, v4.4.2, v4.4.3, v5.0.0, v5.1.0, v5.2.0, v5.3.0, v5.4.0, **v5.5.0 (latest)**
+v1.0, v1.2.0, v2.0.0, v3.0.0, v3.1.0, v3.2.0, v4.0.0, v4.1.0, v4.1.1, v4.1.2, v4.2.0, v4.3.0, v4.4.0, v4.4.1, v4.4.2, v4.4.3, v5.0.0, v5.1.0, v5.2.0, v5.3.0, v5.4.0, v5.5.0, **v6.0.0 (pending)**
 
 ### Useful SQL
 ```sql
@@ -232,6 +225,13 @@ SELECT cron_name, last_ran_at, status, result, error_msg FROM cron_health ORDER 
 SELECT b.external_id, d.name, b.billed_amount, b.night_rate, b.updated_at
 FROM boardings b JOIN dogs d ON b.dog_id = d.id
 ORDER BY b.updated_at DESC LIMIT 20;
+
+-- Tonight's boarders (what Q Boarding box shows)
+SELECT d.name, b.arrival_datetime, b.departure_datetime, b.booking_status
+FROM boardings b JOIN dogs d ON b.dog_id = d.id
+WHERE b.arrival_datetime < (CURRENT_DATE + INTERVAL '1 day')
+  AND b.departure_datetime >= (CURRENT_DATE + INTERVAL '1 day')
+ORDER BY d.name;
 ```
 
 ### GitHub Actions repo secrets / Vercel env vars

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -13,7 +13,7 @@
 ### Session 20 Summary
 | Item | Status |
 |---|---|
-| J-1 — intraday boarding change notification job | ✅ Built — PR open, issue #190 |
+| J-1 — intraday boarding change notification job | ✅ Built — PR #191, issue #190 |
 
 **J-1 changes:**
 - `queryBoarders` now returns `{ name, arrival_datetime, departure_datetime }[]` (was `string[]`)
@@ -69,7 +69,7 @@
 
 ### J-1 — Intraday change notification job ✅ PR OPEN
 
-**Issue:** #190 | **PR:** pending CI
+**Issue:** #190 | **PR:** #191
 
 **Definition of Done:**
 - [x] New GH Actions workflow: hourly 9am–8pm (Mon–Fri), `workflow_dispatch` for manual test

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,5 +1,5 @@
 # Dog Boarding App — Session Handoff (v6 — OPEN)
-**Last updated:** May 1, 2026 (session 20) — J-1 built, PR open, pending CI + merge.
+**Last updated:** May 1, 2026 (session 20) — J-1 built. PR #191 CI green, ready to merge.
 
 ---
 
@@ -7,13 +7,13 @@
 
 - **v6 OPEN** — theme: *Client-driven operational intelligence*
 - **1028 tests, 59 files, 0 failures**
-- **J-1 PR open** — pending CI + merge
+- **J-1 PR #191 — CI green, ready to merge**
 - Live at [qboarding.vercel.app](https://qboarding.vercel.app)
 
 ### Session 20 Summary
 | Item | Status |
 |---|---|
-| J-1 — intraday boarding change notification job | ✅ Built — PR #191, issue #190 |
+| J-1 — intraday boarding change notification job | ✅ PR #191 CI green — ready to merge |
 
 **J-1 changes:**
 - `queryBoarders` now returns `{ name, arrival_datetime, departure_datetime }[]` (was `string[]`)
@@ -69,7 +69,7 @@
 
 ### J-1 — Intraday change notification job ✅ PR OPEN
 
-**Issue:** #190 | **PR:** #191
+**Issue:** #190 | **PR:** #191 | **CI:** ✅ green — merge when ready
 
 **Definition of Done:**
 - [x] New GH Actions workflow: hourly 9am–8pm (Mon–Fri), `workflow_dispatch` for manual test
@@ -141,7 +141,7 @@
 ## v6 Sprint Order (Recommended)
 
 1. **R-1** ✅ DONE — PR #187 + bug fix PR #189
-2. **J-1** — New cron + state design. Architect carefully before building. **NEXT.**
+2. **J-1** ✅ PR #191 CI green — merge + deploy verify + v6.0.0 release tag. **NEXT.**
 3. **P-1** — DB schema change. Needs spec review at architect step.
 
 ---

--- a/docs/SPRINT_PLAN.md
+++ b/docs/SPRINT_PLAN.md
@@ -1,6 +1,6 @@
 # Q Boarding — Sprint Plan
 
-_Last updated: April 29, 2026 (session 18) — **R-1 done (PR #187).** J-1 is next. Theme: Client-driven operational intelligence._
+_Last updated: May 1, 2026 (session 20) — **J-1 PR open (#190).** P-1 is next. Theme: Client-driven operational intelligence._
 
 ---
 
@@ -93,8 +93,8 @@ These are not code tickets. They block specific milestones. Track them here so n
 
 **Why this order:**
 
-1. **R-1** ✅ Q Boarding 6th box — done PR #187
-2. **J-1** — Intraday change notification job. New cron + state design. Architect carefully before building.
+1. **R-1** ✅ Q Boarding 6th box — PR #187 + bug fix PR #189 (queryBoarders now uses boardings table)
+2. **J-1** ✅ PR open issue #190 — Intraday change notification job.
 3. **P-1** — Employee pay daytime follow-on. DB schema change, needs spec review at architect step.
 
 ---

--- a/docs/SPRINT_PLAN.md
+++ b/docs/SPRINT_PLAN.md
@@ -1,6 +1,6 @@
 # Q Boarding — Sprint Plan
 
-_Last updated: May 1, 2026 (session 20) — **J-1 PR #191 open.** P-1 is next. Theme: Client-driven operational intelligence._
+_Last updated: May 1, 2026 (session 20) — **J-1 PR #191 CI green, ready to merge.** After merge: v6.0.0 release, then P-1. Theme: Client-driven operational intelligence._
 
 ---
 

--- a/docs/SPRINT_PLAN.md
+++ b/docs/SPRINT_PLAN.md
@@ -1,6 +1,6 @@
 # Q Boarding — Sprint Plan
 
-_Last updated: May 1, 2026 (session 20) — **J-1 PR open (#190).** P-1 is next. Theme: Client-driven operational intelligence._
+_Last updated: May 1, 2026 (session 20) — **J-1 PR #191 open.** P-1 is next. Theme: Client-driven operational intelligence._
 
 ---
 
@@ -94,7 +94,7 @@ These are not code tickets. They block specific milestones. Track them here so n
 **Why this order:**
 
 1. **R-1** ✅ Q Boarding 6th box — PR #187 + bug fix PR #189 (queryBoarders now uses boardings table)
-2. **J-1** ✅ PR open issue #190 — Intraday change notification job.
+2. **J-1** ✅ PR #191 — Intraday change notification job.
 3. **P-1** — Employee pay daytime follow-on. DB schema change, needs spec review at architect step.
 
 ---

--- a/docs/job_docs/notify-jobs.md
+++ b/docs/job_docs/notify-jobs.md
@@ -1,22 +1,23 @@
 # Notify Jobs (WhatsApp Roster)
 
-**Status:** Live (weekdays + Friday PM, PDT schedule — update UTC times each DST transition)
-**Last reviewed:** April 2, 2026
+**Status:** Live (weekdays + Friday PM + hourly intraday, PDT schedule — update UTC times each DST transition)
+**Last reviewed:** May 1, 2026
 
 ---
 
 ## What They Do
 
-Four GitHub Actions workflows send WhatsApp notifications. Three fire on weekday mornings with the daily roster image; one fires Friday afternoon with a weekend boarding preview.
+Five GitHub Actions workflows send WhatsApp notifications. Three fire on weekday mornings with the daily roster image; one fires Friday afternoon with a weekend boarding preview; one fires hourly throughout the day to catch intraday boarding changes.
 
 | Workflow | File | Time (PDT) | UTC | Days | Behavior |
 |---|---|---|---|---|---|
 | Notify 4am | `notify-4am.yml` | 4:00 AM | 11:00 | Mon–Fri | Always sends — daily roster image |
 | Notify 7am | `notify-7am.yml` | 7:00 AM | 14:00 | Mon–Fri | Sends only if roster changed |
-| Notify 8:30am | `notify-830am.yml` | 8:30 AM | 15:30 | Mon–Fri | Sends only if roster changed |
+| Notify 8:30am | `notify-830am.yml` | 8:30 AM | 15:30 | Mon–Fri | Sends only if roster changed; also stores boarders snapshot |
 | Notify Friday PM | `notify-friday-pm.yml` | 3:00 PM | 22:00 | Fri only | Always sends — weekend boarding preview image |
+| Notify Intraday | `notify-intraday.yml` | 9am–8pm hourly | 16–23 + 0–3 UTC | Mon–Fri | Sends delta image only when boarders changed since 8:30am |
 
-All four support manual trigger (`workflow_dispatch`) for testing.
+All five support manual trigger (`workflow_dispatch`) for testing.
 
 ---
 
@@ -64,12 +65,38 @@ The endpoint orchestrates the full notify flow:
 
 ## Change Detection
 
-The roster hash is computed from the current set of {worker → dog name} pairs. If any worker's dog changes (new booking, cancellation, name correction), the hash changes and the 7am/8:30am sends fire.
+### Morning roster hash (4am / 7am / 8:30am)
+
+The roster hash is computed from the current set of {worker → dog name} pairs **plus the list of overnight boarders** (sorted by name). If any worker's dog changes, or if a new boarder is added/cancelled, the hash changes and the 7am/8:30am sends fire.
+
+This is a change from v4.1.1 where boarders were intentionally excluded from the hash. As of J-1 (v6.0.0), boarders are rendered in the Q Boarding box (R-1/PR #187) and included in the hash so boarder additions/removals trigger a resend.
 
 Hash is stored in `cron_health WHERE cron_name = 'notify'`. Check it with:
 
 ```sql
 SELECT result FROM cron_health WHERE cron_name = 'notify';
+```
+
+### Intraday delta (hourly job)
+
+The 8:30am notify run stores a snapshot of tonight's boarders in `cron_health`:
+```sql
+SELECT result FROM cron_health WHERE cron_name = 'boarders-snapshot';
+-- result: { snapshotDate, boarders: [{name, arrival_datetime, departure_datetime}], capturedAt }
+```
+
+Each hourly run:
+1. Loads the snapshot (rejects if `snapshotDate` ≠ today — stale row from a prior day)
+2. Queries current boarders from the `boardings` table
+3. Computes delta: `added` = in current but not in snapshot; `cancelled` = in snapshot but not in current
+4. Hashes the delta (djb2 over sorted names). If hash matches the last intraday send, skips — nothing new since the last hourly image
+5. If delta is empty, skips
+6. If delta is non-empty and new, sends the intraday delta image
+
+Last intraday state stored in `cron_health WHERE cron_name = 'notify-intraday'`:
+```sql
+SELECT result FROM cron_health WHERE cron_name = 'notify-intraday';
+-- result: { lastDeltaHash, lastDate, sentAt, addedCount, cancelledCount }
 ```
 
 ---
@@ -115,11 +142,14 @@ The notify endpoint itself (running in Vercel) also needs these env vars set in 
 |---|---|
 | `.github/workflows/notify-4am.yml` | 4am weekday workflow — always sends daily roster |
 | `.github/workflows/notify-7am.yml` | 7am weekday workflow — sends on change |
-| `.github/workflows/notify-830am.yml` | 8:30am weekday workflow — sends on change |
+| `.github/workflows/notify-830am.yml` | 8:30am weekday workflow — sends on change; triggers boarders snapshot |
 | `.github/workflows/notify-friday-pm.yml` | Friday 3pm workflow — always sends weekend boarding preview |
-| `api/notify.js` | Notify orchestrator endpoint (handles all windows incl. friday-pm) |
-| `api/roster-image.js` | PNG image generation endpoint (satori + resvg, token-gated; supports `type=weekend`) |
-| `src/lib/pictureOfDay.js` | `getPictureOfDay()`, `computeWorkerDiff()`, `hashPicture()` |
+| `.github/workflows/notify-intraday.yml` | Hourly 9am–8pm PDT Mon–Fri — sends delta image when boarders changed since 8:30am |
+| `api/notify.js` | Notify orchestrator endpoint (handles all windows incl. friday-pm); stores boarders snapshot at 8:30am |
+| `api/notify-intraday.js` | Intraday delta handler — snapshot read, delta compute, hash gate, send |
+| `api/roster-image.js` | PNG image generation endpoint (satori + resvg, token-gated; supports `type=weekend`); Q Boarding card shows compact date ranges |
+| `api/intraday-image.js` | Intraday delta PNG endpoint (satori + resvg, token-gated); shows added/cancelled boarders |
+| `src/lib/pictureOfDay.js` | `getPictureOfDay()`, `computeWorkerDiff()`, `hashPicture()`, `queryBoarders()` |
 | `src/lib/notifyHelpers.js` | `refreshDaytimeSchedule()` — live schedule refresh before each send |
 | `src/lib/notifyWhatsApp.js` | Meta Cloud API wrapper — `metaMediaUpload()` (K-1b upload-first), `sendRosterImage()`, `sendTextMessage()`, `getRecipients()` |
 

--- a/src/__tests__/intradayImage.test.js
+++ b/src/__tests__/intradayImage.test.js
@@ -1,0 +1,120 @@
+/**
+ * Tests for intraday-image.js pure layout functions.
+ * @requirements REQ-J1
+ *
+ * intraday-image.js has top-level readFileSync calls (font loading) and imports from
+ * notify-intraday.js that re-export computeIntradayDelta. Modules with side effects
+ * are mocked before import.
+ */
+
+import { vi, describe, it, expect } from 'vitest';
+
+// Mock modules with top-level side effects BEFORE importing intraday-image.
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, readFileSync: vi.fn(() => Buffer.alloc(0)) };
+});
+vi.mock('@resvg/resvg-js', () => ({ Resvg: vi.fn() }));
+vi.mock('satori', () => ({ default: vi.fn() }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn() }));
+vi.mock('../lib/pictureOfDay.js', () => ({
+  queryBoarders: vi.fn(),
+  parseDateParam: vi.fn(),
+}));
+vi.mock('../../api/notify-intraday.js', async (importOriginal) => {
+  // Import the actual module so we get the real computeIntradayDelta logic.
+  const actual = await importOriginal();
+  return { ...actual };
+});
+
+import {
+  buildIntradayLayout,
+  computeIntradayImageHeight,
+} from '../../api/intraday-image.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function boarder(name, arrival = '2026-04-29T07:00:00Z', departure = '2026-05-02T10:00:00Z') {
+  return { name, arrival_datetime: arrival, departure_datetime: departure };
+}
+
+// ---------------------------------------------------------------------------
+// buildIntradayLayout
+// ---------------------------------------------------------------------------
+
+describe('buildIntradayLayout', () => {
+  it('renders added section with correct dog names and date ranges', () => {
+    const layout = buildIntradayLayout({
+      date: '2026-04-29',
+      added: [boarder('Mochi Hill', '2026-04-29T07:00:00Z', '2026-05-02T10:00:00Z')],
+      cancelled: [],
+      asOfStr: '2:00 PM',
+    });
+    const str = JSON.stringify(layout);
+    expect(str).toContain('Q Boarding Changes');
+    expect(str).toContain('Wednesday, April 29');
+    expect(str).toContain('Added');
+    expect(str).toContain('Mochi Hill');
+    // Date range should be readable: "Apr 29 – May 2"
+    expect(str).toContain('Apr 29');
+    expect(str).toContain('May 2');
+    expect(str).toContain('as of 2:00 PM');
+  });
+
+  it('renders cancelled section correctly', () => {
+    const layout = buildIntradayLayout({
+      date: '2026-04-29',
+      added: [],
+      cancelled: [boarder('Tula', '2026-04-27T07:00:00Z', '2026-05-01T10:00:00Z')],
+      asOfStr: null,
+    });
+    const str = JSON.stringify(layout);
+    expect(str).toContain('Cancelled');
+    expect(str).toContain('Tula');
+    expect(str).toContain('Apr 27');
+    expect(str).toContain('May 1');
+    // No "as of" when null
+    expect(str).not.toContain('as of');
+    // Header fallback
+    expect(str).toContain('since 8:30 AM');
+  });
+
+  it('renders both added and cancelled sections when both are present', () => {
+    const layout = buildIntradayLayout({
+      date: '2026-04-29',
+      added: [boarder('Bronwyn')],
+      cancelled: [boarder('Tula')],
+      asOfStr: '11:00 AM',
+    });
+    const str = JSON.stringify(layout);
+    expect(str).toContain('Added');
+    expect(str).toContain('Cancelled');
+    expect(str).toContain('Bronwyn');
+    expect(str).toContain('Tula');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeIntradayImageHeight
+// ---------------------------------------------------------------------------
+
+describe('computeIntradayImageHeight', () => {
+  it('returns correct height for N added + M cancelled', () => {
+    const h1 = computeIntradayImageHeight({ added: [boarder('A')], cancelled: [] });
+    const h2 = computeIntradayImageHeight({ added: [], cancelled: [boarder('B')] });
+    const h3 = computeIntradayImageHeight({ added: [boarder('A'), boarder('B')], cancelled: [boarder('C')] });
+
+    // More rows → taller image
+    expect(h3).toBeGreaterThan(h1);
+    expect(h3).toBeGreaterThan(h2);
+    expect(h1).toBeGreaterThan(0);
+  });
+
+  it('returns header height only when delta is empty', () => {
+    const empty = computeIntradayImageHeight({ added: [], cancelled: [] });
+    const withDog = computeIntradayImageHeight({ added: [boarder('A')], cancelled: [] });
+    expect(withDog).toBeGreaterThan(empty);
+  });
+});

--- a/src/__tests__/notifyIntraday.test.js
+++ b/src/__tests__/notifyIntraday.test.js
@@ -1,0 +1,268 @@
+/**
+ * Tests for notify-intraday.js — intraday boarding change notification.
+ * @requirements REQ-J1
+ *
+ * Pure functions (computeIntradayDelta, hashDelta) are tested directly.
+ * Handler tests inject a fake Supabase client and mock send/record calls
+ * so no real DB or network access is needed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock external clients before importing the module under test.
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn() }));
+vi.mock('../../src/lib/notifyWhatsApp.js', () => ({
+  sendRosterImage: vi.fn(),
+  getRecipients: vi.fn(),
+}));
+vi.mock('../../src/lib/messageDeliveryStatus.js', () => ({
+  recordSentMessages: vi.fn().mockResolvedValue(undefined),
+  recordMessageLog: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../src/lib/pictureOfDay.js', () => ({
+  queryBoarders: vi.fn(),
+}));
+vi.mock('../../api/_cronHealth.js', () => ({
+  writeCronHealth: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock the global fetch used by the image store path
+global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) });
+
+import {
+  computeIntradayDelta,
+  hashDelta,
+  default as handler,
+} from '../../api/notify-intraday.js';
+import { sendRosterImage, getRecipients } from '../../src/lib/notifyWhatsApp.js';
+import { queryBoarders } from '../../src/lib/pictureOfDay.js';
+import { createClient } from '@supabase/supabase-js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function boarder(name, arrival = '2026-04-29T07:00:00Z', departure = '2026-05-02T10:00:00Z') {
+  return { name, arrival_datetime: arrival, departure_datetime: departure };
+}
+
+// Compute today's Pacific date dynamically — matches the handler's own Intl logic.
+const TODAY = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Los_Angeles' }).format(new Date());
+
+// Minimal supabase mock — returns cron_health rows by cron_name.
+function buildSupaMock({ snapshotResult = null, intradayResult = null } = {}) {
+  const storage = {
+    from: vi.fn().mockReturnValue({
+      upload: vi.fn().mockResolvedValue({ error: null }),
+    }),
+  };
+
+  return {
+    storage,
+    from: vi.fn((table) => {
+      if (table !== 'cron_health') return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) };
+
+      const chain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn((col, val) => {
+          if (col === 'cron_name' && val === 'boarders-snapshot') {
+            chain._result = snapshotResult;
+          } else if (col === 'cron_name' && val === 'notify-intraday') {
+            chain._result = intradayResult;
+          }
+          return chain;
+        }),
+        maybeSingle: vi.fn(async () => ({
+          data: chain._result ? { result: chain._result } : null,
+          error: null,
+        })),
+        _result: null,
+      };
+      return chain;
+    }),
+  };
+}
+
+function buildReq(token = 'test-token') {
+  return {
+    method: 'GET',
+    query: { token },
+    headers: { host: 'localhost:3000' },
+  };
+}
+
+function buildRes() {
+  const res = {
+    _status: null,
+    _body: null,
+    status: vi.fn((code) => { res._status = code; return res; }),
+    json: vi.fn((body) => { res._body = body; return res; }),
+  };
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// computeIntradayDelta — pure function unit tests
+// ---------------------------------------------------------------------------
+
+describe('computeIntradayDelta', () => {
+  it('dog in current but not snapshot → added', () => {
+    const snapshot = [boarder('Mochi')];
+    const current = [boarder('Mochi'), boarder('Bronwyn')];
+    const { added, cancelled } = computeIntradayDelta(snapshot, current);
+    expect(added.map(b => b.name)).toEqual(['Bronwyn']);
+    expect(cancelled).toHaveLength(0);
+  });
+
+  it('dog in snapshot but not current → cancelled', () => {
+    const snapshot = [boarder('Mochi'), boarder('Tula')];
+    const current = [boarder('Mochi')];
+    const { added, cancelled } = computeIntradayDelta(snapshot, current);
+    expect(added).toHaveLength(0);
+    expect(cancelled.map(b => b.name)).toEqual(['Tula']);
+  });
+
+  it('dog in both → neither added nor cancelled', () => {
+    const snapshot = [boarder('Mochi')];
+    const current = [boarder('Mochi')];
+    const { added, cancelled } = computeIntradayDelta(snapshot, current);
+    expect(added).toHaveLength(0);
+    expect(cancelled).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hashDelta
+// ---------------------------------------------------------------------------
+
+describe('hashDelta', () => {
+  it('returns the same hash for identical deltas', () => {
+    const added = [boarder('Bronwyn')];
+    const cancelled = [boarder('Tula')];
+    expect(hashDelta(added, cancelled)).toBe(hashDelta(added, cancelled));
+  });
+
+  it('returns the same hash regardless of order (sorted by name)', () => {
+    const a1 = [boarder('Zoe'), boarder('Apple')];
+    const a2 = [boarder('Apple'), boarder('Zoe')];
+    expect(hashDelta(a1, [])).toBe(hashDelta(a2, []));
+  });
+
+  it('returns a different hash for different deltas', () => {
+    expect(hashDelta([boarder('Mochi')], [])).not.toBe(hashDelta([boarder('Bronwyn')], []));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler — skip scenarios
+// ---------------------------------------------------------------------------
+
+describe('notify-intraday handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.VITE_SYNC_PROXY_TOKEN = 'test-token';
+    process.env.VITE_SUPABASE_URL = 'https://fake.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'fake-key';
+  });
+
+  it('skips with no_snapshot when no 8:30am snapshot for today', async () => {
+    createClient.mockReturnValue(buildSupaMock({ snapshotResult: null }));
+    queryBoarders.mockResolvedValue([boarder('Mochi')]);
+    getRecipients.mockReturnValue(['+18312477375']);
+
+    const req = buildReq();
+    const res = buildRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, action: 'skipped', reason: 'no_snapshot' });
+  });
+
+  it('skips with no_change_since_830am when delta is empty', async () => {
+    const snapshotResult = {
+      snapshotDate: TODAY,
+      boarders: [boarder('Mochi')],
+      capturedAt: '2026-04-30T15:30:00Z',
+    };
+    createClient.mockReturnValue(buildSupaMock({ snapshotResult, intradayResult: null }));
+    // Current boarders identical to snapshot → empty delta
+    queryBoarders.mockResolvedValue([boarder('Mochi')]);
+    getRecipients.mockReturnValue(['+18312477375']);
+
+    const req = buildReq();
+    const res = buildRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, action: 'skipped', reason: 'no_change_since_830am' });
+  });
+
+  it('skips with delta_unchanged when hash matches last intraday send', async () => {
+    const snapshotResult = {
+      snapshotDate: TODAY,
+      boarders: [boarder('Mochi')],
+      capturedAt: '2026-04-30T15:30:00Z',
+    };
+    // Bronwyn was added vs snapshot
+    const currentBoarders = [boarder('Mochi'), boarder('Bronwyn')];
+    // Compute the hash that would result from this delta
+    const expectedHash = hashDelta([boarder('Bronwyn')], []);
+
+    const intradayResult = {
+      lastDeltaHash: expectedHash,
+      lastDate: TODAY,
+    };
+    createClient.mockReturnValue(buildSupaMock({ snapshotResult, intradayResult }));
+    queryBoarders.mockResolvedValue(currentBoarders);
+    getRecipients.mockReturnValue(['+18312477375']);
+
+    const req = buildReq();
+    const res = buildRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, action: 'skipped', reason: 'delta_unchanged' });
+  });
+
+  it('sends when addition detected', async () => {
+    const snapshotResult = {
+      snapshotDate: TODAY,
+      boarders: [boarder('Mochi')],
+      capturedAt: '2026-04-30T15:30:00Z',
+    };
+    createClient.mockReturnValue(buildSupaMock({ snapshotResult, intradayResult: null }));
+    // Bronwyn added since 8:30am
+    queryBoarders.mockResolvedValue([boarder('Mochi'), boarder('Bronwyn')]);
+    getRecipients.mockReturnValue(['+18312477375']);
+    sendRosterImage.mockResolvedValue([{ to: '+18312477375', status: 'sent', messageId: 'wamid.abc' }]);
+
+    const req = buildReq();
+    const res = buildRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, action: 'sent', addedCount: 1, cancelledCount: 0 });
+    expect(sendRosterImage).toHaveBeenCalledOnce();
+  });
+
+  it('sends when cancellation detected', async () => {
+    const snapshotResult = {
+      snapshotDate: TODAY,
+      boarders: [boarder('Mochi'), boarder('Tula')],
+      capturedAt: '2026-04-30T15:30:00Z',
+    };
+    createClient.mockReturnValue(buildSupaMock({ snapshotResult, intradayResult: null }));
+    // Tula cancelled since 8:30am
+    queryBoarders.mockResolvedValue([boarder('Mochi')]);
+    getRecipients.mockReturnValue(['+18312477375']);
+    sendRosterImage.mockResolvedValue([{ to: '+18312477375', status: 'sent', messageId: 'wamid.def' }]);
+
+    const req = buildReq();
+    const res = buildRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, action: 'sent', addedCount: 0, cancelledCount: 1 });
+    expect(sendRosterImage).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/pictureOfDay.test.js
+++ b/src/__tests__/pictureOfDay.test.js
@@ -135,7 +135,7 @@ describe('hashPicture', () => {
     const data = {
       date: DATE,
       workers: [{ workerId: 61023, dogs: [{ series_id: 'SRS001', pet_names: ['Benny'] }] }],
-      boarders: ['Millie'],
+      boarders: [{ name: 'Millie', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z' }],
     };
     expect(hashPicture(data)).toBe(hashPicture(data));
   });
@@ -150,11 +150,29 @@ describe('hashPicture', () => {
     expect(hashPicture(base)).not.toBe(hashPicture(changed));
   });
 
-  it('returns the same hash regardless of boarder changes (boarders excluded in v4.1.1)', () => {
-    // Boarders are no longer rendered or hashed — boarder changes must not trigger a resend.
-    const base = { date: DATE, workers: [], boarders: ['Benny'] };
-    const changed = { date: DATE, workers: [], boarders: ['Millie'] };
-    expect(hashPicture(base)).toBe(hashPicture(changed));
+  it('returns a different hash when boarders change (boarders included as of J-1/v6)', () => {
+    // Boarders are rendered in the Q Boarding box (R-1) — boarder changes must trigger a resend.
+    const base = { date: DATE, workers: [], boarders: [{ name: 'Benny', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-01T00:00:00Z' }] };
+    const changed = { date: DATE, workers: [], boarders: [{ name: 'Millie', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-01T00:00:00Z' }] };
+    expect(hashPicture(base)).not.toBe(hashPicture(changed));
+  });
+
+  it('returns the same hash regardless of boarder order (sorted by name)', () => {
+    const a = {
+      date: DATE, workers: [],
+      boarders: [
+        { name: 'Zoe', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-01T00:00:00Z' },
+        { name: 'Apple', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-01T00:00:00Z' },
+      ],
+    };
+    const b = {
+      date: DATE, workers: [],
+      boarders: [
+        { name: 'Apple', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-01T00:00:00Z' },
+        { name: 'Zoe', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-01T00:00:00Z' },
+      ],
+    };
+    expect(hashPicture(a)).toBe(hashPicture(b));
   });
 
   it('returns the same hash regardless of lastSyncedAt (timestamp must not trigger resend)', () => {
@@ -410,44 +428,48 @@ describe('getPictureOfDay diff logic', () => {
     expect(result.workers.every(w => w.workerId !== 0)).toBe(true);
   });
 
-  it('boarders: returns dog names from boardings table (not daytime_appointments)', async () => {
+  it('boarders: returns dog objects from boardings table (not daytime_appointments)', async () => {
     const boarderRows = [
-      { booking_status: 'confirmed', dogs: { name: 'Mochi' } },
-      { booking_status: null, dogs: { name: 'Bronwyn' } },
+      { booking_status: 'confirmed', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z', dogs: { name: 'Mochi' } },
+      { booking_status: null,        arrival_datetime: '2026-04-28T00:00:00Z', departure_datetime: '2026-05-01T00:00:00Z', dogs: { name: 'Bronwyn' } },
     ];
     const supa = buildSupaMock({ boarderRows });
 
     const result = await getPictureOfDay(supa, parseDateParam(DATE));
 
     expect(result.boarders).toHaveLength(2);
-    expect(result.boarders).toContain('Mochi');
-    expect(result.boarders).toContain('Bronwyn');
+    expect(result.boarders.map(b => b.name)).toContain('Mochi');
+    expect(result.boarders.map(b => b.name)).toContain('Bronwyn');
+    expect(result.boarders[0]).toHaveProperty('arrival_datetime');
+    expect(result.boarders[0]).toHaveProperty('departure_datetime');
   });
 
   it('boarders: excludes cancelled bookings', async () => {
     const boarderRows = [
-      { booking_status: 'confirmed', dogs: { name: 'Mochi' } },
-      { booking_status: 'cancelled', dogs: { name: 'Ghost' } },
+      { booking_status: 'confirmed', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z', dogs: { name: 'Mochi' } },
+      { booking_status: 'cancelled', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z', dogs: { name: 'Ghost' } },
     ];
     const supa = buildSupaMock({ boarderRows });
 
     const result = await getPictureOfDay(supa, parseDateParam(DATE));
 
-    expect(result.boarders).toEqual(['Mochi']);
+    expect(result.boarders).toHaveLength(1);
+    expect(result.boarders[0].name).toBe('Mochi');
   });
 
   it('boarders: deduplicates dogs that appear in multiple boarding rows', async () => {
     // Mirrors the Annie/Tracy bug: AGYD gave two appointment IDs for the same stay,
     // causing the sync to create two boarding rows for the same dog.
     const boarderRows = [
-      { booking_status: 'confirmed', dogs: { name: 'Annie' } },
-      { booking_status: 'confirmed', dogs: { name: 'Annie' } }, // duplicate row
+      { booking_status: 'confirmed', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z', dogs: { name: 'Annie' } },
+      { booking_status: 'confirmed', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z', dogs: { name: 'Annie' } },
     ];
     const supa = buildSupaMock({ boarderRows });
 
     const result = await getPictureOfDay(supa, parseDateParam(DATE));
 
-    expect(result.boarders).toEqual(['Annie']);
+    expect(result.boarders).toHaveLength(1);
+    expect(result.boarders[0].name).toBe('Annie');
   });
 
   it('boarders: returns empty array when no boardings overlap', async () => {

--- a/src/__tests__/rosterImage.test.js
+++ b/src/__tests__/rosterImage.test.js
@@ -285,15 +285,19 @@ describe('computeWeekendImageHeight', () => {
 describe('qBoardingCard', () => {
   const COL_WIDTH = 240;
 
+  function boarder(name, arrival = '2026-04-29T00:00:00Z', departure = '2026-05-02T00:00:00Z') {
+    return { name, arrival_datetime: arrival, departure_datetime: departure };
+  }
+
   it('renders heading "Q Boarding" with correct dog count', () => {
-    const card = qBoardingCard(['Mochi', 'Bronwyn', 'Tula'], COL_WIDTH);
+    const card = qBoardingCard([boarder('Mochi'), boarder('Bronwyn'), boarder('Tula')], COL_WIDTH);
     const cardStr = JSON.stringify(card);
     expect(cardStr).toContain('Q Boarding');
     expect(cardStr).toContain('3 dogs');
   });
 
   it('sorts boarders alphabetically (case-insensitive)', () => {
-    const card = qBoardingCard(['Tula', 'bronwyn', 'Mochi'], COL_WIDTH);
+    const card = qBoardingCard([boarder('Tula'), boarder('bronwyn'), boarder('Mochi')], COL_WIDTH);
     const cardStr = JSON.stringify(card);
     const bronwynIdx = cardStr.indexOf('bronwyn');
     const mochiIdx = cardStr.indexOf('Mochi');
@@ -301,6 +305,15 @@ describe('qBoardingCard', () => {
     // bronwyn < Mochi < Tula alphabetically
     expect(bronwynIdx).toBeLessThan(mochiIdx);
     expect(mochiIdx).toBeLessThan(tulaIdx);
+  });
+
+  it('renders compact date range in each dog row', () => {
+    const card = qBoardingCard([boarder('Mochi', '2026-04-29T07:00:00Z', '2026-05-02T10:00:00Z')], COL_WIDTH);
+    const cardStr = JSON.stringify(card);
+    // Compact format: "Mochi (4/29–5/2)" — month/day without leading zero in en-US locale
+    expect(cardStr).toContain('Mochi');
+    expect(cardStr).toContain('4/29');
+    expect(cardStr).toContain('5/2');
   });
 
   it('renders "(none tonight)" when boarders list is empty', () => {
@@ -311,7 +324,7 @@ describe('qBoardingCard', () => {
   });
 
   it('uses singular "dog" for exactly 1 boarder', () => {
-    const card = qBoardingCard(['Mochi'], COL_WIDTH);
+    const card = qBoardingCard([boarder('Mochi')], COL_WIDTH);
     expect(JSON.stringify(card)).toContain('1 dog');
     expect(JSON.stringify(card)).not.toContain('1 dogs');
   });
@@ -336,14 +349,15 @@ describe('computeImageHeight', () => {
 
   it('grows when boarders list is longer (Q Boarding card is taller)', () => {
     const workers = [makeWorker(1), makeWorker(1), makeWorker(1), makeWorker(1), makeWorker(1)];
+    const makeBoarder = (name) => ({ name, arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z' });
     const shortBoarders = { workers, boarders: [] };
-    const longBoarders = { workers, boarders: ['A','B','C','D','E','F','G','H','I','J'] };
+    const longBoarders = { workers, boarders: 'ABCDEFGHIJ'.split('').map(makeBoarder) };
     expect(computeImageHeight(longBoarders)).toBeGreaterThan(computeImageHeight(shortBoarders));
   });
 
   it('empty boarders still reserves 1 row (no zero-height Q Boarding card)', () => {
     const withZero = { workers: [makeWorker(0)], boarders: [] };
-    const withOne = { workers: [makeWorker(0)], boarders: ['Mochi'] };
+    const withOne = { workers: [makeWorker(0)], boarders: [{ name: 'Mochi', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z' }] };
     // Both reserve 1 row in Q Boarding — height should be equal
     expect(computeImageHeight(withZero)).toBe(computeImageHeight(withOne));
   });

--- a/src/lib/pictureOfDay.js
+++ b/src/lib/pictureOfDay.js
@@ -133,7 +133,8 @@ async function queryAppointmentsByDate(supabase, dateStr, label) {
 
 /**
  * Query boarding dogs present overnight on a given date.
- * Returns a deduplicated array of dog name strings.
+ * Returns a deduplicated array of `{ name, arrival_datetime, departure_datetime }` objects.
+ * The richer shape lets callers (intraday image, J-1 delta) show date ranges per dog.
  *
  * Uses the boardings table (source of truth for overnight stays) rather than
  * daytime_appointments service_category='Boarding', which only captures dogs
@@ -149,9 +150,9 @@ async function queryAppointmentsByDate(supabase, dateStr, label) {
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @param {string} dateStr - YYYY-MM-DD
- * @returns {Promise<string[]>}
+ * @returns {Promise<Array<{name: string, arrival_datetime: string, departure_datetime: string}>>}
  */
-async function queryBoarders(supabase, dateStr) {
+export async function queryBoarders(supabase, dateStr) {
   log(`Querying boarders for ${dateStr} (from boardings table)`);
 
   // Midnight of dateStr+1 in local time — dogs staying overnight must depart
@@ -165,7 +166,7 @@ async function queryBoarders(supabase, dateStr) {
 
   const { data, error } = await supabase
     .from('boardings')
-    .select('booking_status, dogs(name)')
+    .select('booking_status, arrival_datetime, departure_datetime, dogs(name)')
     .lt('arrival_datetime', nextDayISO)
     .gte('departure_datetime', nextDayISO);
 
@@ -184,11 +185,11 @@ async function queryBoarders(supabase, dateStr) {
     const name = row.dogs?.name;
     if (name && !seen.has(name)) {
       seen.add(name);
-      boarders.push(name);
+      boarders.push({ name, arrival_datetime: row.arrival_datetime, departure_datetime: row.departure_datetime });
     }
   }
 
-  log(`Boarders today: ${boarders.length} (${boarders.join(', ') || 'none'})`);
+  log(`Boarders today: ${boarders.length} (${boarders.map(b => b.name).join(', ') || 'none'})`);
   return boarders;
 }
 
@@ -433,7 +434,8 @@ export async function getPictureOfDay(supabase, date) {
   log(`getPictureOfDay complete — ${workers.length} workers, ${boarders.length} boarders, hasUpdates: ${hasUpdates}, lastSyncedAt: ${lastSyncedAt ?? 'none'}`);
 
   // lastSyncedAt: ISO string or null. Rendered as "(as of HH:MM AM)" in the image header.
-  // boarders: kept in data struct for easy restoration; not rendered or hashed in v4.1.1+.
+  // boarders: { name, arrival_datetime, departure_datetime }[] — rendered in Q Boarding box
+  //   (R-1/PR #187) and included in hashPicture (J-1) so boarder changes trigger a resend.
   return { date: dateStr, workers, boarders, hasUpdates, lastSyncedAt };
 }
 
@@ -452,8 +454,9 @@ export async function getPictureOfDay(supabase, date) {
  * @returns {string} Unsigned 32-bit integer as a decimal string
  */
 export function hashPicture(data) {
-  // Decision: boarders intentionally excluded from hash in v4.1.1.
-  // Boarder changes should not trigger a resend since boarders are not rendered.
+  // boarders included in hash as of J-1 (v6): boarders are rendered in the Q Boarding box
+  // (R-1/PR #187) so boarder additions/removals must trigger a resend.
+  // Sorted by name for stability — DB query order may vary.
   // lastSyncedAt intentionally excluded — timestamp changes must not trigger resend.
   const key = JSON.stringify({
     date: data.date,
@@ -462,6 +465,7 @@ export function hashPicture(data) {
       // Use series_id as the stable identifier; fall back to pet names for null-series rows.
       dogs: w.dogs.map(d => d.series_id || d.pet_names.join(',')),
     })),
+    boarders: data.boarders.map(b => b.name).sort(),
   });
 
   // djb2 hash — fast, sufficient entropy for change detection.


### PR DESCRIPTION
Closes #190

## Summary

- **`queryBoarders` returns rich objects** (`{ name, arrival_datetime, departure_datetime }[]`) so date ranges can be displayed per dog
- **`hashPicture` now includes boarders** — boarders are rendered in Q Boarding box (R-1/PR #187), so boarder additions/cancellations must trigger a resend. Removes the v4.1.1 exclusion
- **Q Boarding card shows compact date ranges** — `Name (M/D–M/D)` format using `formatCompactDateRange`
- **8:30am notify stores boarders snapshot** — written to `cron_health` (`cron_name='boarders-snapshot'`) before the send-gate check, so the hourly job always has a baseline even on no-change mornings
- **`api/notify-intraday.js`** — hourly delta handler: reads snapshot → queries current boarders → computes `added`/`cancelled` delta → djb2 hash gate (skips if delta unchanged since last send) → sends "Q Boarding Changes" intraday image
- **`api/intraday-image.js`** — delta PNG: Forest Green header "Q Boarding Changes · [date] | since 8:30 AM (as of [time])", ✅ Added and ❌ Cancelled sections with readable date ranges `Name (Apr 29 – May 2)`
- **`.github/workflows/notify-intraday.yml`** — hourly 9am–8pm PDT Mon–Fri (two cron expressions because 5pm–8pm PDT spans UTC midnight); `workflow_dispatch` for manual testing

## Test plan

- [x] 1028 tests, 59 files, 0 failures
- [x] `computeIntradayDelta` unit tests: added, cancelled, unchanged
- [x] `hashDelta` unit tests: stable, sorted, distinct
- [x] Handler skip tests: no_snapshot, no_change_since_830am, delta_unchanged
- [x] Handler send tests: addition detected, cancellation detected
- [x] `buildIntradayLayout`: added section with date ranges, cancelled section, both combined
- [x] `computeIntradayImageHeight`: grows with more rows
- [x] `hashPicture` boarders-included tests: different boarders → different hash, different order → same hash
- [x] `qBoardingCard` objects: renders compact date range, sorts alphabetically, empty state
- [ ] Verify on a real morning cycle after merge (8:30am snapshot → 9am+ hourly runs)
