### PR TITLE
feat: P-1 — employee pay daytime follow-on (#192)

### DIFF
--- a/src/components/EmployeeDropdown.jsx
+++ b/src/components/EmployeeDropdown.jsx
@@ -3,11 +3,19 @@ import { useData } from '../context/DataContext';
 import { getEmployeeName, isEmployeeActive } from '../utils/employeeHelpers';
 
 export default function EmployeeDropdown({ date }) {
-  const { settings, getNightAssignment, setNightAssignment } = useData();
+  const { settings, getNightAssignment, setNightAssignment, getWorkedFollowingDay, setWorkedFollowingDay } = useData();
   const [saving, setSaving] = useState(false);
+  const [checkboxSaving, setCheckboxSaving] = useState(false);
   const [error, setError] = useState(null);
 
   const selectedEmployee = getNightAssignment(date);
+  const workedFollowingDay = getWorkedFollowingDay ? getWorkedFollowingDay(date) : null;
+
+  const followingDay = (() => {
+    const d = new Date(date + 'T00:00:00');
+    d.setDate(d.getDate() + 1);
+    return d.toLocaleDateString('en-US', { weekday: 'short', month: 'numeric', day: 'numeric' });
+  })();
 
   const handleChange = async (e) => {
     const newValue = e.target.value;
@@ -18,10 +26,21 @@ export default function EmployeeDropdown({ date }) {
     } catch (err) {
       console.error('Failed to set assignment:', err);
       setError(err.message);
-      // Reset dropdown to previous value after brief error display
       setTimeout(() => setError(null), 3000);
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleFollowingDayChange = async (e) => {
+    const checked = e.target.checked;
+    setCheckboxSaving(true);
+    try {
+      await setWorkedFollowingDay(date, checked ? true : null);
+    } catch (err) {
+      console.error('Failed to set worked_following_day:', err);
+    } finally {
+      setCheckboxSaving(false);
     }
   };
 
@@ -30,26 +49,43 @@ export default function EmployeeDropdown({ date }) {
     isEmployeeActive(emp) || getEmployeeName(emp) === selectedEmployee
   );
 
+  const showFollowingDayCheckbox = selectedEmployee && selectedEmployee !== 'N/A';
+
   return (
-    <select
-      value={selectedEmployee}
-      onChange={handleChange}
-      disabled={saving}
-      className={`w-full text-xs px-2 py-1.5 border rounded-lg bg-white text-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 ${
-        error ? 'border-red-500 bg-red-50' : 'border-slate-300'
-      } ${saving ? 'opacity-50 cursor-wait' : ''}`}
-      title={error || ''}
-    >
-      <option value="">—</option>
-      <option value="N/A">N/A</option>
-      {availableEmployees.map((employee) => {
-        const name = getEmployeeName(employee);
-        return (
-          <option key={name} value={name}>
-            {name}
-          </option>
-        );
-      })}
-    </select>
+    <div className="space-y-1">
+      <select
+        value={selectedEmployee}
+        onChange={handleChange}
+        disabled={saving}
+        className={`w-full text-xs px-2 py-1.5 border rounded-lg bg-white text-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 ${
+          error ? 'border-red-500 bg-red-50' : 'border-slate-300'
+        } ${saving ? 'opacity-50 cursor-wait' : ''}`}
+        title={error || ''}
+      >
+        <option value="">—</option>
+        <option value="N/A">N/A</option>
+        {availableEmployees.map((employee) => {
+          const name = getEmployeeName(employee);
+          return (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          );
+        })}
+      </select>
+
+      {showFollowingDayCheckbox && (
+        <label className={`flex items-center gap-1.5 cursor-pointer ${checkboxSaving ? 'opacity-50' : ''}`}>
+          <input
+            type="checkbox"
+            checked={!!workedFollowingDay}
+            onChange={handleFollowingDayChange}
+            disabled={checkboxSaving}
+            className="w-3 h-3 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+          />
+          <span className="text-xs text-slate-500">Also worked {followingDay}</span>
+        </label>
+      )}
+    </div>
   );
 }

--- a/src/context/DataContext.jsx
+++ b/src/context/DataContext.jsx
@@ -6,6 +6,7 @@ import { useBoardings as useSupabaseBoardings } from '../hooks/useBoardings';
 import { useNightAssignments as useSupabaseNightAssignments } from '../hooks/useNightAssignments';
 import { usePayments as useSupabasePayments } from '../hooks/usePayments';
 import { logger } from '../utils/logger';
+import { supabase } from '../lib/supabase';
 
 const DataContext = createContext(null);
 
@@ -59,6 +60,8 @@ export function DataProvider({ children }) {
     loading: nightAssignmentsLoading,
     setNightAssignment: setSupabaseNightAssignment,
     getNightAssignment: getSupabaseNightAssignment,
+    getWorkedFollowingDay: getSupabaseWorkedFollowingDay,
+    setWorkedFollowingDay: setSupabaseWorkedFollowingDay,
     deleteAssignmentsForEmployee: deleteSupabaseAssignmentsForEmployee,
   } = useSupabaseNightAssignments(supabaseEmployees);
 
@@ -298,6 +301,28 @@ export function DataProvider({ children }) {
     return getSupabasePaidDatesForEmployee(employeeName);
   };
 
+  // Returns a map of { [dateStr]: string[] } of unique DC/PG pet names for each requested date.
+  const queryDaytimePetNames = async (datesToQuery) => {
+    if (!datesToQuery || datesToQuery.length === 0) return {};
+    const { data, error } = await supabase
+      .from('daytime_appointments')
+      .select('appointment_date, pet_names')
+      .in('appointment_date', datesToQuery)
+      .in('service_category', ['DC', 'PG']);
+    if (error) {
+      console.error('[DataContext] queryDaytimePetNames error:', error);
+      return {};
+    }
+    const result = {};
+    for (const row of data ?? []) {
+      const d = row.appointment_date;
+      if (!result[d]) result[d] = new Set();
+      for (const name of row.pet_names ?? []) result[d].add(name);
+    }
+    for (const d of Object.keys(result)) result[d] = [...result[d]];
+    return result;
+  };
+
   const value = {
     // Data
     dogs,
@@ -334,6 +359,9 @@ export function DataProvider({ children }) {
     // Night assignment operations
     setNightAssignment,
     getNightAssignment,
+    getWorkedFollowingDay: getSupabaseWorkedFollowingDay,
+    setWorkedFollowingDay: setSupabaseWorkedFollowingDay,
+    queryDaytimePetNames,
     // Payment operations
     addPayment,
     deletePayment,

--- a/src/hooks/useNightAssignments.js
+++ b/src/hooks/useNightAssignments.js
@@ -30,6 +30,7 @@ export function useNightAssignments(employees = []) {
         id: a.id,
         date: a.date,
         employeeId: a.employee_id,
+        workedFollowingDay: a.worked_following_day ?? null,
       })));
     } catch (err) {
       console.error('Error fetching night assignments:', err);
@@ -105,6 +106,7 @@ export function useNightAssignments(employees = []) {
           id: data.id,
           date: data.date,
           employeeId: data.employee_id,
+          workedFollowingDay: data.worked_following_day ?? null,
         }]);
       }
     } catch (err) {
@@ -120,6 +122,28 @@ export function useNightAssignments(employees = []) {
     if (assignment.employeeId === null) return 'N/A';
     return getEmployeeNameById(employees, assignment.employeeId) || '';
   }, [nightAssignments, employees]);
+
+  const getWorkedFollowingDay = useCallback((date) => {
+    const assignment = nightAssignments.find(a => a.date === date);
+    return assignment?.workedFollowingDay ?? null;
+  }, [nightAssignments]);
+
+  const setWorkedFollowingDay = useCallback(async (date, value) => {
+    if (!user) return;
+    const existing = nightAssignments.find(a => a.date === date);
+    if (!existing) return;
+
+    const { error } = await supabase
+      .from('night_assignments')
+      .update({ worked_following_day: value })
+      .eq('id', existing.id);
+
+    if (error) throw error;
+
+    setNightAssignments(prev => prev.map(a =>
+      a.id === existing.id ? { ...a, workedFollowingDay: value } : a
+    ));
+  }, [user, nightAssignments]);
 
   // For deleting assignments when an employee is deleted
   const deleteAssignmentsForEmployee = async (employeeName) => {
@@ -150,6 +174,8 @@ export function useNightAssignments(employees = []) {
     error,
     setNightAssignment,
     getNightAssignment,
+    getWorkedFollowingDay,
+    setWorkedFollowingDay,
     deleteAssignmentsForEmployee,
     refresh: fetchNightAssignments,
   };

--- a/src/pages/PayrollPage.jsx
+++ b/src/pages/PayrollPage.jsx
@@ -4,7 +4,7 @@ import DateNavigator from '../components/DateNavigator';
 import ConfirmDialog from '../components/ConfirmDialog';
 import PaymentDialog from '../components/PaymentDialog';
 import { getDateRange } from '../utils/dateUtils';
-import { calculateGross } from '../utils/calculations';
+import { calculateGross, calculateDaytimeCredit } from '../utils/calculations';
 
 export default function PayrollPage() {
   const {
@@ -13,6 +13,8 @@ export default function PayrollPage() {
     payments,
     getNetPercentageForDate,
     getNightAssignment,
+    nightAssignments,
+    queryDaytimePetNames,
     addPayment,
     deletePayment,
     getPaidDatesForEmployee,
@@ -54,8 +56,42 @@ export default function PayrollPage() {
   const [payConfirm, setPayConfirm] = useState({ isOpen: false, employee: null });
   const [deleteConfirm, setDeleteConfirm] = useState({ isOpen: false, payment: null });
 
+  // daytimeCreditByNightDate: { [nightDateStr]: number } — credit earned for the following day
+  const [daytimeCreditByNightDate, setDaytimeCreditByNightDate] = useState({});
+
   const daysDiff = Math.floor((endDate - startDate) / (1000 * 60 * 60 * 24)) + 1;
   const dates = getDateRange(startDate, daysDiff);
+
+  // Fetch daytime pet names for nights where worked_following_day = true, then compute credits
+  useEffect(() => {
+    if (!nightAssignments) return;
+
+    const followingDayDates = nightAssignments
+      .filter(a => a.workedFollowingDay && dates.includes(a.date))
+      .map(a => {
+        const d = new Date(a.date + 'T00:00:00');
+        d.setDate(d.getDate() + 1);
+        return { nightDate: a.date, followingDate: d.toISOString().split('T')[0] };
+      });
+
+    if (followingDayDates.length === 0) {
+      setDaytimeCreditByNightDate({});
+      return;
+    }
+
+    const uniqueFollowingDates = [...new Set(followingDayDates.map(x => x.followingDate))];
+
+    queryDaytimePetNames(uniqueFollowingDates).then(petsByDate => {
+      const credits = {};
+      for (const { nightDate, followingDate } of followingDayDates) {
+        const petNames = petsByDate[followingDate] ?? [];
+        const percentage = getNetPercentageForDate(nightDate);
+        credits[nightDate] = calculateDaytimeCredit(petNames, dogs, percentage);
+      }
+      setDaytimeCreditByNightDate(credits);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nightAssignments, dogs, startDate, endDate]);
 
   // Calculate net for a specific date
   const calculateDayNet = (dateStr) => {
@@ -111,21 +147,20 @@ export default function PayrollPage() {
     const outstanding = {};
 
     for (const dateStr of dates) {
-      // Use getNightAssignment to resolve employee name from ID
       const employeeName = getNightAssignment(dateStr);
       if (employeeName && employeeName !== 'N/A') {
         const paidDates = getPaidDatesForEmployee(employeeName);
-
-        // Skip if already paid
         if (paidDates.includes(dateStr)) continue;
 
-        const net = calculateDayNet(dateStr);
+        const nightNet = calculateDayNet(dateStr);
+        const daytimeNet = daytimeCreditByNightDate[dateStr] ?? 0;
 
         if (!outstanding[employeeName]) {
-          outstanding[employeeName] = { nights: 0, amount: 0, dates: [] };
+          outstanding[employeeName] = { nights: 0, amount: 0, daytimeAmount: 0, dates: [] };
         }
         outstanding[employeeName].nights += 1;
-        outstanding[employeeName].amount += net;
+        outstanding[employeeName].amount += nightNet + daytimeNet;
+        outstanding[employeeName].daytimeAmount += daytimeNet;
         outstanding[employeeName].dates.push(dateStr);
       }
     }
@@ -262,10 +297,20 @@ export default function PayrollPage() {
                       <span className="font-semibold text-slate-700 bg-slate-200/60 px-2 py-0.5 rounded-md">{emp.nights}</span>
                     </div>
                     <div className="flex justify-between items-center">
-                      <span className="text-slate-500">Amount owed</span>
+                      <span className="text-slate-500">Night pay</span>
+                      <span className="font-semibold text-slate-700">{formatCurrency(emp.amount - emp.daytimeAmount)}</span>
+                    </div>
+                    {emp.daytimeAmount > 0 && (
+                      <div className="flex justify-between items-center">
+                        <span className="text-slate-500">+ Daytime follow-on</span>
+                        <span className="font-semibold text-indigo-600">{formatCurrency(emp.daytimeAmount)}</span>
+                      </div>
+                    )}
+                    <div className="flex justify-between items-center pt-1 border-t border-slate-200">
+                      <span className="text-slate-600 font-medium">Total owed</span>
                       <span className="font-semibold text-amber-600">{formatCurrency(emp.amount)}</span>
                     </div>
-                    <div className="pt-2 mt-2 border-t border-slate-200">
+                    <div className="pt-1">
                       <span className="text-slate-500 text-xs">Dates: </span>
                       <span className="text-slate-600 text-xs">{formatDateRanges(emp.dates)}</span>
                     </div>

--- a/src/pages/PayrollPage.test.jsx
+++ b/src/pages/PayrollPage.test.jsx
@@ -75,15 +75,26 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
   const mockAddPayment = vi.fn();
   const mockDeletePayment = vi.fn();
   const mockGetPaidDatesForEmployee = vi.fn(() => []);
+  const mockQueryDaytimePetNames = vi.fn().mockResolvedValue({});
+
+  // nightAssignments array (shape mirrors useNightAssignments return value)
+  const mockNightAssignmentsArray = [
+    { id: '1', date: dates.day1, employeeId: 'emp-1', workedFollowingDay: null },
+    { id: '2', date: dates.day2, employeeId: 'emp-1', workedFollowingDay: null },
+    { id: '3', date: dates.day3, employeeId: 'emp-2', workedFollowingDay: null },
+  ];
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetPaidDatesForEmployee.mockReturnValue([]);
+    mockQueryDaytimePetNames.mockResolvedValue({});
     useData.mockReturnValue({
       dogs: mockDogs,
       boardings: mockBoardings,
       settings: mockSettings,
       getNightAssignment: (date) => mockNightAssignments[date] || '',
+      nightAssignments: mockNightAssignmentsArray,
+      queryDaytimePetNames: mockQueryDaytimePetNames,
       payments: [],
       getNetPercentageForDate: () => 65,
       addPayment: mockAddPayment,
@@ -117,6 +128,8 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
         boardings: [],
         settings: mockSettings,
         getNightAssignment: () => '',
+        nightAssignments: [],
+        queryDaytimePetNames: mockQueryDaytimePetNames,
         payments: [],
         getNetPercentageForDate: () => 65,
         addPayment: mockAddPayment,
@@ -138,6 +151,8 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
         boardings: mockBoardings,
         settings: mockSettings,
         getNightAssignment: (date) => assignments[date] || '',
+        nightAssignments: mockNightAssignmentsArray,
+        queryDaytimePetNames: mockQueryDaytimePetNames,
         payments: [],
         getNetPercentageForDate: () => 65,
         addPayment: mockAddPayment,
@@ -164,6 +179,8 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
         boardings: mockBoardings,
         settings: mockSettings,
         getNightAssignment: (date) => mockNightAssignments[date] || '',
+        nightAssignments: mockNightAssignmentsArray,
+        queryDaytimePetNames: mockQueryDaytimePetNames,
         payments: [{
           id: '1',
           employeeName: 'Kate',
@@ -248,6 +265,8 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
         boardings: mockBoardings,
         settings: mockSettings,
         getNightAssignment: () => '',
+        nightAssignments: [],
+        queryDaytimePetNames: mockQueryDaytimePetNames,
         payments: [{
           id: '1',
           employeeName: 'Kate',
@@ -277,6 +296,8 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
         boardings: mockBoardings,
         settings: mockSettings,
         getNightAssignment: () => '',
+        nightAssignments: [],
+        queryDaytimePetNames: mockQueryDaytimePetNames,
         payments: [{
           id: '1',
           employeeName: 'Kate',
@@ -309,6 +330,8 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
         boardings: mockBoardings,
         settings: mockSettings,
         getNightAssignment: () => '',
+        nightAssignments: [],
+        queryDaytimePetNames: mockQueryDaytimePetNames,
         payments: [{
           id: 'payment-1',
           employeeName: 'Kate',
@@ -356,6 +379,8 @@ describe('REQ-041, REQ-042, REQ-043: PayrollPage', () => {
         boardings: [],
         settings: mockSettings,
         getNightAssignment: () => '',
+        nightAssignments: [],
+        queryDaytimePetNames: mockQueryDaytimePetNames,
         payments: [],
         getNetPercentageForDate: () => 65,
         addPayment: mockAddPayment,

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -83,6 +83,27 @@ export function calculateEmployeeTotals(nightAssignments, dogs, boardings, dates
 }
 
 /**
+ * Calculate daytime follow-on credit for a worker who worked the following day.
+ * Matches pet names from daytime_appointments against the dogs array by name
+ * and sums their dayRate × (netPercentage / 100).
+ * @param {string[]} petNames - Unique pet names with daytime appointments that day
+ * @param {Array} dogs - Dogs array with { name, dayRate }
+ * @param {number} netPercentage - Net percentage (0-100)
+ * @returns {number} - Daytime credit amount
+ */
+export function calculateDaytimeCredit(petNames, dogs, netPercentage) {
+  let gross = 0;
+  const seen = new Set();
+  for (const name of petNames) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const dog = dogs.find(d => d.name === name);
+    if (dog) gross += dog.dayRate ?? 0;
+  }
+  return gross * (netPercentage / 100);
+}
+
+/**
  * Calculate total gross revenue for a boarding
  * @param {Object} dog - Dog with nightRate
  * @param {Object} boarding - Boarding with arrival/departure

--- a/src/utils/calculations.test.js
+++ b/src/utils/calculations.test.js
@@ -5,6 +5,7 @@ import {
   countOvernightDogs,
   calculateEmployeeTotals,
   calculateBoardingGross,
+  calculateDaytimeCredit,
 } from './calculations';
 
 const sampleDogs = [
@@ -200,5 +201,48 @@ describe('REQ-063: calculateBoardingGross', () => {
     const dates = ['2025-01-14', '2025-01-19'];
     const gross = calculateBoardingGross(luna, lunaBoarding, dates);
     expect(gross).toBe(0);
+  });
+});
+
+/**
+ * @requirements REQ-P1
+ */
+describe('REQ-P1: calculateDaytimeCredit', () => {
+  const dogs = [
+    { name: 'Luna', dayRate: 35 },
+    { name: 'Cooper', dayRate: 35 },
+    { name: 'Bella', dayRate: 40 },
+  ];
+
+  it('returns 0 when petNames is empty (no daytime dogs)', () => {
+    expect(calculateDaytimeCredit([], dogs, 65)).toBe(0);
+  });
+
+  it('computes credit for matching dogs at the given net percentage', () => {
+    // Luna ($35) + Cooper ($35) = $70 gross → $70 × 0.65 = $45.50
+    const credit = calculateDaytimeCredit(['Luna', 'Cooper'], dogs, 65);
+    expect(credit).toBeCloseTo(45.5);
+  });
+
+  it('skips pet names not in the dogs array (unrecognized dog)', () => {
+    // Only Bella ($40) matches → $40 × 0.65 = $26
+    const credit = calculateDaytimeCredit(['Bella', 'Unknown'], dogs, 65);
+    expect(credit).toBeCloseTo(26);
+  });
+
+  it('deduplicates repeated pet names', () => {
+    // Luna appears twice — should only be counted once: $35 × 0.65 = $22.75
+    const credit = calculateDaytimeCredit(['Luna', 'Luna'], dogs, 65);
+    expect(credit).toBeCloseTo(22.75);
+  });
+
+  it('returns 0 when net percentage is 0', () => {
+    expect(calculateDaytimeCredit(['Luna', 'Cooper'], dogs, 0)).toBe(0);
+  });
+
+  it('uses the full dayRate when percentage is 100', () => {
+    // Luna ($35) + Bella ($40) = $75 at 100%
+    const credit = calculateDaytimeCredit(['Luna', 'Bella'], dogs, 100);
+    expect(credit).toBeCloseTo(75);
   });
 });

--- a/supabase/migrations/027_add_worked_following_day.sql
+++ b/supabase/migrations/027_add_worked_following_day.sql
@@ -1,0 +1,5 @@
+-- P-1: Employee pay daytime follow-on
+-- Tracks whether the night shift worker also worked the following calendar day.
+-- NULL = not set (treated as false). TRUE = credit daytime dogs at net_percentage.
+ALTER TABLE night_assignments
+  ADD COLUMN IF NOT EXISTS worked_following_day BOOLEAN DEFAULT NULL;


### PR DESCRIPTION
## P-1 — Employee pay daytime follow-on

Closes #192.

## Summary

- **Migration 027:** Adds `worked_following_day BOOLEAN DEFAULT NULL` to `night_assignments` — one optional flag per night assignment
- **Checkbox UI:** "Also worked [Sun M/D]?" appears below the employee dropdown when a worker is assigned to a night. Unchecked by default.
- **Payroll calculation:** When the flag is true, fetches DC/PG pet names from `daytime_appointments` for the following calendar day, matches them to `dogs[].dayRate` by name, and computes `sum(dayRate) × net_percentage`
- **Payroll display:** Shows "Night pay" and "+ Daytime follow-on" as separate line items; "Total owed" is their sum
- **DataContext:** New `queryDaytimePetNames(dates[])` keeps all Supabase calls behind the DataContext boundary (testable via mock)

## What to do after merge

1. Run `supabase/migrations/027_add_worked_following_day.sql` in the Supabase SQL editor
2. Verify on live site: assign a worker to a past night, tick "Also worked [day]?", confirm daytime credit line appears in Payroll

## Test plan

- [x] `calculateDaytimeCredit` — 6 new unit tests: (a) no dogs → $0, (b) matching dogs → correct credit, (c) unknown pet name skipped, (d) duplicates deduped, (e) 0% → $0, (f) 100% → full dayRate sum
- [x] `PayrollPage` — existing 15 tests pass with updated mocks (`nightAssignments`, `queryDaytimePetNames`)
- [x] `EmployeeDropdown` — existing 10 tests pass
- [x] 1034 total tests, 0 failures, 100% requirement coverage
