### PR TITLE
feat: N-1 — suppress UPDATED! badge on 4am; blue intra-day diff on 7am/8:30am (#196)

### DIFF
--- a/api/notify.js
+++ b/api/notify.js
@@ -198,6 +198,7 @@ async function readLastSentState(supabase) {
   return {
     lastHash: data.result.lastHash,
     lastDate: data.result.lastDate || '',
+    lastSnapshot: data.result.snapshot || null,
   };
 }
 
@@ -239,7 +240,7 @@ async function storeBoardersSnapshot(supabase, boarders, dateStr) {
  * @param {string} window  - '4am' | '7am' | '8:30am'
  * @param {Array} sendResults - From sendRosterImage
  */
-async function persistSentState(supabase, hash, dateStr, window, sendResults) {
+async function persistSentState(supabase, hash, dateStr, window, sendResults, workers) {
   await writeCronHealth(supabase, 'notify', 'success', {
     lastHash: hash,
     lastDate: dateStr,
@@ -247,6 +248,7 @@ async function persistSentState(supabase, hash, dateStr, window, sendResults) {
     sentAt: new Date().toISOString(),
     recipients: sendResults.map(r => r.to), // already masked
     results: sendResults,
+    snapshot: workers,
   }, null);
 }
 
@@ -397,8 +399,11 @@ export default async function handler(req, res) {
 
     // Decision: if last send was for a different date, treat as no baseline.
     // This ensures the 7am gate doesn't compare against yesterday's hash.
-    const lastHash = (lastState?.lastDate === dateStr) ? lastState.lastHash : null;
-    if (lastState?.lastDate && lastState.lastDate !== dateStr) {
+    const sameDate = lastState?.lastDate === dateStr;
+    const lastHash = sameDate ? lastState.lastHash : null;
+    // lastSnapshot: only used for intra-day blue overlay on 7am/8:30am. Not needed for 4am.
+    const lastSnapshot = (window !== '4am' && sameDate) ? (lastState.lastSnapshot || null) : null;
+    if (lastState?.lastDate && !sameDate) {
       console.log(`[Notify] Last send was for ${lastState.lastDate} (different date) — resetting baseline`);
     }
 
@@ -419,10 +424,15 @@ export default async function handler(req, res) {
     // --- Construct image URL ---
     // Use the request's own host so this works for any deployment (prod, preview, local).
     // ts param passes the job run time to roster-image.js for the "as of" header line.
+    // sendWindow drives badge suppression (4am has no prior send to diff against).
+    // lastSnapshot (7am/8:30am only) enables the blue intra-day overlay in roster-image.js.
     const protocol = req.headers['x-forwarded-proto'] || 'https';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
-    const imageUrl = `${protocol}://${host}/api/roster-image?date=${dateStr}&token=${expectedToken}&ts=${encodeURIComponent(jobRunAt)}`;
-    console.log(`[Notify] Image URL: ${protocol}://${host}/api/roster-image?date=${dateStr}&token=***&ts=${encodeURIComponent(jobRunAt)}`);
+    let imageUrl = `${protocol}://${host}/api/roster-image?date=${dateStr}&token=${expectedToken}&ts=${encodeURIComponent(jobRunAt)}&sendWindow=${window}`;
+    if (lastSnapshot) {
+      imageUrl += `&lastSnapshot=${Buffer.from(JSON.stringify(lastSnapshot)).toString('base64')}`;
+    }
+    console.log(`[Notify] Image URL: ${protocol}://${host}/api/roster-image?date=${dateStr}&token=***&ts=${encodeURIComponent(jobRunAt)}&sendWindow=${window}${lastSnapshot ? '&lastSnapshot=<snapshot>' : ''}`);
 
     // --- Get recipients ---
     const recipients = getRecipients();
@@ -448,7 +458,7 @@ export default async function handler(req, res) {
     );
 
     // --- Persist state (non-fatal) ---
-    await persistSentState(supabase, currentHash, dateStr, window, sendResults);
+    await persistSentState(supabase, currentHash, dateStr, window, sendResults, data.workers);
 
     const sentCount = sendResults.filter(r => r.status === 'sent').length;
     const failedCount = sendResults.filter(r => r.status === 'failed').length;

--- a/api/roster-image.js
+++ b/api/roster-image.js
@@ -87,6 +87,7 @@ const COLORS = {
   added: '#16a34a',          // green-600 — functional indicator, keep
   removed: '#dc2626',        // red-600 — functional indicator, keep
   unchanged: '#333333',      // Deep Charcoal — body text
+  intraday: '#2563eb',       // blue-600 — dog changed since previous send
   clientName: '#6b7280',     // gray-500
   updated: '#ea580c',        // orange-600 — functional indicator, keep
 };
@@ -192,6 +193,56 @@ export function formatAsOf(isoStr) {
 }
 
 // ---------------------------------------------------------------------------
+// Intra-day change detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a Set of dog keys that changed between the previous send (lastSnapshot)
+ * and the current workers state.
+ *
+ * A dog is "changed" if it appeared, disappeared (now isRemoved), or flipped
+ * isAdded/isRemoved state since the last send. Blue takes priority in workerCard.
+ *
+ * Key format: `${workerId}:${series_id}` (or `${workerId}:${pet_names[0]}` when
+ * series_id is null — conservative fallback matching by first pet name).
+ *
+ * @param {Array|null} lastSnapshot - workers array from the previous send, or null
+ * @param {Array} currentWorkers    - current data.workers from getPictureOfDay
+ * @returns {Set<string>}
+ */
+export function buildChangedDogs(lastSnapshot, currentWorkers) {
+  const changedDogs = new Set();
+  if (!lastSnapshot || !Array.isArray(lastSnapshot)) return changedDogs;
+
+  // Build snapshot map: key → { isAdded, isRemoved }
+  const snapshotMap = new Map();
+  for (const worker of lastSnapshot) {
+    if (!Array.isArray(worker.dogs)) continue;
+    for (const dog of worker.dogs) {
+      const key = dog.series_id != null
+        ? `${worker.workerId}:${dog.series_id}`
+        : `${worker.workerId}:${dog.pet_names?.[0]}`;
+      snapshotMap.set(key, { isAdded: dog.isAdded, isRemoved: dog.isRemoved });
+    }
+  }
+
+  // For each currently rendered dog, mark as changed if new or state flipped
+  for (const worker of currentWorkers) {
+    for (const dog of worker.dogs) {
+      const key = dog.series_id != null
+        ? `${worker.workerId}:${dog.series_id}`
+        : `${worker.workerId}:${dog.pet_names?.[0]}`;
+      const prev = snapshotMap.get(key);
+      if (!prev || prev.isAdded !== dog.isAdded || prev.isRemoved !== dog.isRemoved) {
+        changedDogs.add(key);
+      }
+    }
+  }
+
+  return changedDogs;
+}
+
+// ---------------------------------------------------------------------------
 // Per-worker card
 // ---------------------------------------------------------------------------
 
@@ -202,16 +253,24 @@ export function formatAsOf(isoStr) {
  * color-coded prefix indicator. Removed dogs get a strikethrough via
  * text-decoration (satori supports this).
  *
- * @param {object} worker   - From getPictureOfDay result
- * @param {number} colWidth - Pixel width of this column
+ * Blue (COLORS.intraday) takes priority over green/red when the dog's key
+ * is present in changedDogs — indicating a change since the previous send.
+ *
+ * @param {object} worker       - From getPictureOfDay result
+ * @param {number} colWidth     - Pixel width of this column
+ * @param {Set<string>} changedDogs - Keys of dogs that changed since last send
  * @returns {object}
  */
-function workerCard(worker, colWidth) {
+function workerCard(worker, colWidth, changedDogs = new Set()) {
   const todayDogCount = worker.dogs.filter(d => !d.isRemoved).length;
 
   const dogRows = worker.dogs.map(dog => {
     const label = dogLabel(dog.pet_names, dog.client_name);
-    const color = dog.isAdded ? COLORS.added : dog.isRemoved ? COLORS.removed : COLORS.unchanged;
+    const dogKey = dog.series_id != null
+      ? `${worker.workerId}:${dog.series_id}`
+      : `${worker.workerId}:${dog.pet_names?.[0]}`;
+    const isChanged = changedDogs.has(dogKey);
+    const color = isChanged ? COLORS.intraday : dog.isAdded ? COLORS.added : dog.isRemoved ? COLORS.removed : COLORS.unchanged;
     const prefix = dog.isAdded ? '+' : dog.isRemoved ? '−' : ' ';
     const decoration = dog.isRemoved ? 'line-through' : 'none';
 
@@ -480,12 +539,13 @@ export function computeImageHeight(data) {
  *
  * data.boarders is rendered as the "Q Boarding" 6th box (bottom-right slot).
  *
- * @param {object} data       - getPictureOfDay result
- * @param {string|null} asOfStr - Pre-formatted "as of" string (e.g. "6:04 PM, Mon 3/16"),
- *   or null if no timestamp is available. Caller is responsible for formatting via formatAsOf().
+ * @param {object} data            - getPictureOfDay result
+ * @param {string|null} asOfStr    - Pre-formatted "as of" string, or null
+ * @param {string} sendWindow      - '4am' | '7am' | '8:30am' | '' — controls badge display
+ * @param {Set<string>} changedDogs - Keys of dogs changed since last send (blue overlay)
  * @returns {object} Satori element tree
  */
-function buildLayout(data, asOfStr) {
+export function buildLayout(data, asOfStr, sendWindow = '', changedDogs = new Set()) {
   const cols = columnsPerRow(data.workers.length);
   const availableWidth = IMAGE_WIDTH - OUTER_PAD * 2;
   const colWidth = Math.floor((availableWidth - COL_GAP * (cols - 1)) / cols);
@@ -514,15 +574,16 @@ function buildLayout(data, asOfStr) {
           item === Q_BOARDING
             ? qBoardingCard(data.boarders, colWidth)
             : item
-            ? workerCard(item, colWidth)
+            ? workerCard(item, colWidth, changedDogs)
             : h('div', { width: colWidth, flexShrink: 0 }) // empty spacer
         ),
       )
     );
   }
 
-  // "UPDATED!" badge — shown when there are diffs vs. yesterday.
-  const updatedBadge = data.hasUpdates
+  // "UPDATED!" badge — shown when there are diffs vs. yesterday, but never on
+  // the 4am send (no prior send exists to compare against; badge is meaningless).
+  const updatedBadge = data.hasUpdates && sendWindow !== '4am'
     ? h('span', {
         fontFamily: 'Inter',
         fontWeight: 700,
@@ -941,7 +1002,27 @@ export default async function handler(req, res) {
     const asOfSource = tsParam ? 'ts param (notify job)' : data.lastSyncedAt ? 'lastSyncedAt (DB)' : 'none';
     console.log(`[RosterImage] as-of: "${asOfStr ?? 'none'}" (source: ${asOfSource})`);
 
-    const element = buildLayout(data, asOfStr);
+    // Parse sendWindow for badge suppression (4am → no UPDATED! badge).
+    const sendWindow = req.query.sendWindow || '';
+
+    // Parse lastSnapshot for the blue intra-day overlay (7am/8:30am only).
+    // Graceful fallback: malformed or missing param → no blue overlay, green/red only.
+    let lastSnapshot = null;
+    const rawSnapshot = req.query.lastSnapshot;
+    if (rawSnapshot) {
+      try {
+        lastSnapshot = JSON.parse(Buffer.from(rawSnapshot, 'base64').toString('utf8'));
+      } catch {
+        console.warn('[RosterImage] lastSnapshot param is malformed — rendering green/red only');
+      }
+    }
+
+    const changedDogs = buildChangedDogs(lastSnapshot, data.workers);
+    if (changedDogs.size > 0) {
+      console.log(`[RosterImage] intra-day blue overlay: ${changedDogs.size} changed dog(s): [${[...changedDogs].join(', ')}]`);
+    }
+
+    const element = buildLayout(data, asOfStr, sendWindow, changedDogs);
     const height = computeImageHeight(data);
     console.log(`[RosterImage] Computed dimensions: ${IMAGE_WIDTH}x${height}`);
 

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -1,5 +1,5 @@
 # Dog Boarding App — Session Handoff (v6 — OPEN)
-**Last updated:** May 1, 2026 (session 23) — G-2/K-5 closed. N-1 architect plan complete. Ready to build.
+**Last updated:** May 1, 2026 (session 24) — N-1 built. PR open, CI pending.
 
 ---
 
@@ -44,28 +44,17 @@
 
 All v6 specced tickets (R-1, J-1, P-1) are **DONE**. G-2 confirmed done (warning already in code). K-5 closed. Remaining work is from the backlog.
 
-### Next: N-1 — Notify diff UX (architect complete, ready to build)
+### Next: N-1 — Notify diff UX (PR open, CI pending)
 
-**Architect plan:** See full spec in SPRINT_PLAN.md. Summary:
+**Status:** Built this session. PR pending CI + merge. No Kate action required post-merge (cron_health `snapshot` field is additive — no schema migration).
 
-**Item 1 — Badge suppression (4am):**
-- Pass `sendWindow` as query param on image URL in `notify.js`
-- `roster-image.js`: suppress badge when `sendWindow === '4am'`
-- ~5 lines, two files
+**What shipped:**
+- **4am badge suppression:** `sendWindow` param appended to image URL; `roster-image.js` suppresses UPDATED! badge unconditionally on `sendWindow=4am`
+- **Intra-day blue overlay (7am/8:30am):** `persistSentState()` now stores `snapshot: workers` in `cron_health.result`; `readLastSentState()` returns it; 7am/8:30am passes base64-encoded snapshot to `roster-image.js` via `&lastSnapshot=`; `buildChangedDogs()` builds the changed-dog Set; `workerCard()` uses `COLORS.intraday = '#2563eb'` for changed dogs
+- **No-snapshot fallback:** malformed or missing `lastSnapshot` → graceful green/red only, no crash
+- **Tests:** 9 new unit tests in `rosterImage.test.js` — badge suppression (3), blue overlay (3), fallback (3). Total: 1043 tests, 0 failures
 
-**Item 2 — Blue intra-day overlay:**
-- `cron_health.result` is already a JSON object — add `snapshot: workers` alongside `lastHash` (no schema change)
-- `readLastSentState()` returns `lastSnapshot`; `persistSentState()` writes `snapshot: workers`
-- For 7am/8:30am: build `changedDogs` Set (keyed `workerId:series_id`), base64-encode prior snapshot, append `&lastSnapshot=<base64>` to image URL
-- 4am: no `lastSnapshot` param passed → graceful fallback to green/red only
-- `roster-image.js`: parse param, build changedDogs Set, add `COLORS.intraday = '#2563eb'`, blue takes priority in `workerCard()`
-- Fallback key for null series_id: `${workerId}:${pet_names[0]}`
-
-**Files to touch:**
-- `api/notify.js` — URL construction, readLastSentState, persistSentState
-- `api/roster-image.js` — parse sendWindow + lastSnapshot, color logic, buildLayout/workerCard signatures
-- `src/lib/pictureOfDay.js` — probably none
-- `src/__tests__/pictureOfDay.test.js` (or new test file) — badge suppression, blue overlay, no-snapshot fallback
+**Files changed:** `api/notify.js`, `api/roster-image.js`, `src/__tests__/rosterImage.test.js`, `docs/job_docs/notify-jobs.md`, `docs/SESSION_HANDOFF.md`
 
 ### Other backlog candidates (after N-1):
 

--- a/docs/job_docs/notify-jobs.md
+++ b/docs/job_docs/notify-jobs.md
@@ -51,7 +51,12 @@ The endpoint orchestrates the full notify flow:
    - `window=7am` or `window=8:30am` → hashes the current roster; if hash matches stored hash in `cron_health`, skips sending
    - `window=friday-pm` → always sends; generates a weekend-themed image (arrivals + departures Sat–Sun) instead of the daily roster. Writes health record to `cron_health WHERE cron_name = 'notify-friday-pm'`
 
-5. **Generate roster image** — constructs a URL to `/api/roster-image` (same Vercel deployment). The URL includes a `&ts=<jobRunAt ISO>` parameter — `jobRunAt` is captured at the very start of the request so the "as of [time], [day]" line in the image header reflects when the notify job ran, not when the DB was last written. Uses AGYD brand colors (Forest Green `#4A773C`, Sage Green `#78A354`).
+5. **Generate roster image** — constructs a URL to `/api/roster-image` (same Vercel deployment). Params:
+   - `&ts=<jobRunAt ISO>` — job run time for the "as of [time], [day]" header line
+   - `&sendWindow=<window>` — `4am`, `7am`, or `8:30am`. Drives badge display: `4am` suppresses the UPDATED! badge (no prior send exists to compare against)
+   - `&lastSnapshot=<base64>` — (7am/8:30am only) the previous send's workers array, base64-encoded JSON. `roster-image.js` uses this to overlay dogs that changed since the last send in blue, so the recipient can see "what's new since the image you received 3 hours ago"
+
+   Uses AGYD brand colors (Forest Green `#4A773C`, Sage Green `#78A354`). Blue `#2563eb` for intra-day changes.
 
 6. **Upload + send via Meta Cloud API (WhatsApp)** — calls `sendRosterImage()` from `notifyWhatsApp.js`, which executes a two-step flow:
    1. **Upload (K-1b):** fetches the PNG buffer from the image URL, then POSTs it to Meta's media API (`POST /v18.0/{PHONE_NUMBER_ID}/media`, `multipart/form-data`). Returns a stable `media_id` from Meta's CDN. Upload happens once regardless of recipient count.
@@ -59,7 +64,7 @@ The endpoint orchestrates the full notify flow:
 
    **Why upload-first:** Meta silently drops template sends when it cannot fetch image URLs from Vercel endpoints — the API accepts the call and returns a wamid, but the message never reaches the phone. Uploading to Meta's CDN first (K-1b, April 2) eliminates this dependency entirely.
 
-7. **Store hash** — writes the roster hash and roster data to `cron_health` (`notify` row) so the 7am/8:30am windows can compare against it.
+7. **Store hash + snapshot** — writes to `cron_health` (`notify` row): the roster hash (for the no-change gate), plus `snapshot: workers` (the full workers array from `getPictureOfDay`). The next window reads `snapshot` to build the intra-day blue overlay.
 
 ---
 
@@ -68,6 +73,16 @@ The endpoint orchestrates the full notify flow:
 ### Morning roster hash (4am / 7am / 8:30am)
 
 The roster hash is computed from the current set of {worker → dog name} pairs **plus the list of overnight boarders** (sorted by name). If any worker's dog changes, or if a new boarder is added/cancelled, the hash changes and the 7am/8:30am sends fire.
+
+### Intra-day blue overlay (7am / 8:30am images)
+
+When 7am or 8:30am generates an image, `notify.js` reads the `snapshot` from the previous send's `cron_health.result`. It base64-encodes this as `lastSnapshot` and passes it to `roster-image.js`. The image renderer compares each dog's `isAdded`/`isRemoved` state against the snapshot: dogs that appeared, disappeared, or flipped state are shown in blue (`#2563eb`) instead of green/red.
+
+This answers "what changed since the last image you received?" rather than "what changed vs yesterday?". Blue takes priority over green/red.
+
+- **4am**: no prior send → no snapshot → no blue. Falls back to green/red only.
+- **4am**: UPDATED! badge suppressed (no prior send to compare against — badge would be misleading).
+- **7am / 8:30am**: UPDATED! badge shown when `hasUpdates` is true (today vs yesterday diff exists).
 
 This is a change from v4.1.1 where boarders were intentionally excluded from the hash. As of J-1 (v6.0.0), boarders are rendered in the Q Boarding box (R-1/PR #187) and included in the hash so boarder additions/removals trigger a resend.
 

--- a/src/__tests__/rosterImage.test.js
+++ b/src/__tests__/rosterImage.test.js
@@ -33,6 +33,8 @@ import {
   computeWeekendImageHeight,
   qBoardingCard,
   computeImageHeight,
+  buildLayout,
+  buildChangedDogs,
 } from '../../api/roster-image.js';
 
 // ---------------------------------------------------------------------------
@@ -360,5 +362,113 @@ describe('computeImageHeight', () => {
     const withOne = { workers: [makeWorker(0)], boarders: [{ name: 'Mochi', arrival_datetime: '2026-04-29T00:00:00Z', departure_datetime: '2026-05-02T00:00:00Z' }] };
     // Both reserve 1 row in Q Boarding — height should be equal
     expect(computeImageHeight(withZero)).toBe(computeImageHeight(withOne));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// N-1: Badge suppression, blue overlay, no-snapshot fallback
+// ---------------------------------------------------------------------------
+
+function makeData(dogOverrides = {}) {
+  return {
+    date: '2026-03-05',
+    workers: [{
+      workerId: 61023,
+      name: 'Charlie',
+      dogs: [{
+        pet_names: ['Benny'],
+        client_name: 'Kate',
+        series_id: 'SRS001',
+        isAdded: true,
+        isRemoved: false,
+        title: 'DC:FT',
+        ...dogOverrides,
+      }],
+      addedCount: 1,
+      removedCount: 0,
+    }],
+    boarders: [],
+    hasUpdates: true,
+    lastSyncedAt: null,
+  };
+}
+
+describe('N-1: 4am badge suppression', () => {
+  it('does not render UPDATED! badge when sendWindow is 4am and hasUpdates is true', () => {
+    const data = makeData();
+    const element = buildLayout(data, null, '4am');
+    expect(JSON.stringify(element)).not.toContain('UPDATED!');
+  });
+
+  it('renders UPDATED! badge when sendWindow is 7am and hasUpdates is true', () => {
+    const data = makeData();
+    const element = buildLayout(data, null, '7am');
+    expect(JSON.stringify(element)).toContain('UPDATED!');
+  });
+
+  it('renders UPDATED! badge when sendWindow is empty (direct hit) and hasUpdates is true', () => {
+    const data = makeData();
+    const element = buildLayout(data, null, '');
+    expect(JSON.stringify(element)).toContain('UPDATED!');
+  });
+});
+
+describe('N-1: blue intra-day overlay', () => {
+  it('uses intraday blue (#2563eb) for a dog that changed since the previous send', () => {
+    // Snapshot has Benny with isAdded: false — current state has isAdded: true (state flipped)
+    const lastSnapshot = [{
+      workerId: 61023,
+      name: 'Charlie',
+      dogs: [{ pet_names: ['Benny'], series_id: 'SRS001', isAdded: false, isRemoved: false }],
+    }];
+    const data = makeData({ isAdded: true, isRemoved: false });
+    const changedDogs = buildChangedDogs(lastSnapshot, data.workers);
+
+    expect(changedDogs.has('61023:SRS001')).toBe(true);
+
+    const element = buildLayout(data, null, '7am', changedDogs);
+    expect(JSON.stringify(element)).toContain('#2563eb');
+  });
+
+  it('detects a dog that appeared since the last send (not in snapshot)', () => {
+    // Snapshot has no dogs for Charlie — Benny appeared after the last send
+    const lastSnapshot = [{ workerId: 61023, name: 'Charlie', dogs: [] }];
+    const data = makeData({ isAdded: true });
+    const changedDogs = buildChangedDogs(lastSnapshot, data.workers);
+
+    expect(changedDogs.has('61023:SRS001')).toBe(true);
+    expect(JSON.stringify(buildLayout(data, null, '7am', changedDogs))).toContain('#2563eb');
+  });
+
+  it('uses null series_id fallback key (workerId:pet_names[0])', () => {
+    const lastSnapshot = [{ workerId: 61023, name: 'Charlie', dogs: [] }];
+    const data = makeData({ series_id: null, isAdded: true });
+    const changedDogs = buildChangedDogs(lastSnapshot, data.workers);
+
+    expect(changedDogs.has('61023:Benny')).toBe(true);
+  });
+});
+
+describe('N-1: no-snapshot fallback', () => {
+  it('returns an empty Set when lastSnapshot is null', () => {
+    const data = makeData();
+    const changedDogs = buildChangedDogs(null, data.workers);
+    expect(changedDogs.size).toBe(0);
+  });
+
+  it('renders green/red only (no blue) when lastSnapshot is null', () => {
+    const data = makeData({ isAdded: true });
+    const changedDogs = buildChangedDogs(null, data.workers);
+    const element = buildLayout(data, null, '7am', changedDogs);
+    const str = JSON.stringify(element);
+    expect(str).not.toContain('#2563eb');
+    expect(str).toContain('#16a34a'); // green-600 for isAdded
+  });
+
+  it('does not crash and renders all dogs when lastSnapshot is null', () => {
+    const data = makeData();
+    const changedDogs = buildChangedDogs(null, data.workers);
+    const element = buildLayout(data, null, '7am', changedDogs);
+    expect(JSON.stringify(element)).toContain('Benny');
   });
 });


### PR DESCRIPTION
## Summary

Closes #196.

Two independent UX improvements to the roster notify job — shipped in one PR because they're both small and the snapshot mechanism is shared.

**Item 1 — Suppress UPDATED! badge on 4am send**
- `notify.js`: appends `&sendWindow=${window}` to the image URL
- `roster-image.js`: suppresses the badge when `sendWindow === '4am'`
- Rationale: the 4am image is the day's baseline. No prior send exists to compare against, so the badge misleads — it shows "updated vs yesterday" on an image the recipient has never seen before

**Item 2 — Blue intra-day overlay (7am / 8:30am)**
- `notify.js` `persistSentState()`: adds `snapshot: workers` to the JSON written to `cron_health.result` (no schema change — field is additive)
- `notify.js` `readLastSentState()`: returns `lastSnapshot` alongside `lastHash`
- `notify.js` handler: for 7am/8:30am, base64-encodes the prior snapshot and appends `&lastSnapshot=<base64>` to the image URL; 4am omits the param entirely
- `roster-image.js` `buildChangedDogs()`: parses `lastSnapshot`, builds a `Set<string>` of dog keys that appeared, disappeared, or flipped `isAdded`/`isRemoved` state
- `roster-image.js` `workerCard()`: checks `changedDogs` first; blue (`#2563eb`) takes priority over green/red
- `roster-image.js` `buildLayout()`: receives `sendWindow` and `changedDogs`; badge + color logic updated

Key: `${workerId}:${series_id}` — falls back to `${workerId}:${pet_names[0]}` when `series_id` is null.

## Test plan

- [x] 9 new unit tests in `src/__tests__/rosterImage.test.js`:
  - N-1: 4am badge suppression (3 tests)
  - N-1: blue intra-day overlay (3 tests)
  - N-1: no-snapshot fallback (3 tests)
- [x] Full suite: **1043 tests, 0 failures** (was 1034)
- [ ] CI green → merge → verify live on next morning 3-send cycle
- [ ] Confirm 4am image has no UPDATED! badge
- [ ] Confirm 7am/8:30am images show blue dogs where applicable

## Notes

- No migration required: `cron_health.result` is a free-form JSONB column; `snapshot` is additive
- First morning after merge: 4am will write a snapshot; 7am will be the first image with blue overlay potential
- If the 4am send occurs before this deploy, 7am will gracefully fall back to green/red only (null snapshot path is tested)
