### PR TITLE
fix: anchor DC/D/C title filter to start-of-title (#198)

### DIFF
--- a/docs/job_docs/notify-jobs.md
+++ b/docs/job_docs/notify-jobs.md
@@ -9,13 +9,13 @@
 
 Five GitHub Actions workflows send WhatsApp notifications. Three fire on weekday mornings with the daily roster image; one fires Friday afternoon with a weekend boarding preview; one fires hourly throughout the day to catch intraday boarding changes.
 
-| Workflow | File | Time (PDT) | UTC | Days | Behavior |
-|---|---|---|---|---|---|
-| Notify 4am | `notify-4am.yml` | 4:00 AM | 11:00 | Mon–Fri | Always sends — daily roster image |
-| Notify 7am | `notify-7am.yml` | 7:00 AM | 14:00 | Mon–Fri | Sends only if roster changed |
-| Notify 8:30am | `notify-830am.yml` | 8:30 AM | 15:30 | Mon–Fri | Sends only if roster changed; also stores boarders snapshot |
-| Notify Friday PM | `notify-friday-pm.yml` | 3:00 PM | 22:00 | Fri only | Always sends — weekend boarding preview image |
-| Notify Intraday | `notify-intraday.yml` | 9am–8pm hourly | 16–23 + 0–3 UTC | Mon–Fri | Sends delta image only when boarders changed since 8:30am |
+| Workflow         | File                   | Time (PDT)     | UTC             | Days     | Behavior                                                    |
+| ---------------- | ---------------------- | -------------- | --------------- | -------- | ----------------------------------------------------------- |
+| Notify 4am       | `notify-4am.yml`       | 4:00 AM        | 11:00           | Mon–Fri  | Always sends — daily roster image                           |
+| Notify 7am       | `notify-7am.yml`       | 7:00 AM        | 14:00           | Mon–Fri  | Sends only if roster changed                                |
+| Notify 8:30am    | `notify-830am.yml`     | 8:30 AM        | 15:30           | Mon–Fri  | Sends only if roster changed; also stores boarders snapshot |
+| Notify Friday PM | `notify-friday-pm.yml` | 3:00 PM        | 22:00           | Fri only | Always sends — weekend boarding preview image               |
+| Notify Intraday  | `notify-intraday.yml`  | 9am–8pm hourly | 16–23 + 0–3 UTC | Mon–Fri  | Sends delta image only when boarders changed since 8:30am   |
 
 All five support manual trigger (`workflow_dispatch`) for testing.
 

--- a/src/__tests__/scraper/appointmentFilter.test.js
+++ b/src/__tests__/scraper/appointmentFilter.test.js
@@ -13,7 +13,7 @@ import { applyDetailFilters } from '../../lib/scraper/appointmentFilter.js';
 vi.mock('../../lib/scraper/config.js', () => ({
   SCRAPER_CONFIG: {
     nonBoardingPatterns: [
-      /(d\/c|\bdc\b)/i,
+      /^(d\/c|dc)\b/i,
       /\badd\b/i,
       /switch\s+day/i,
       /back\s+to\s+\d+/i,
@@ -89,6 +89,17 @@ describe('title filter', () => {
   it('does NOT skip PG titles — PG is intentionally absent from nonBoardingPatterns', () => {
     const { skip } = applyDetailFilters(
       validBoarding({ service_type: 'PG 3/23-30' }), 'PG 3/23-30',
+    );
+    expect(skip).toBe(false);
+  });
+
+  it('does NOT skip "Boarding discounted nights for DC full-time" — DC mid-title is a pricing tier, not daycare', () => {
+    // Regression: C63QghzF (Peanut/Leo Garver, May 1–5 2026). Service name includes
+    // "DC full-time" as a client tier descriptor. The old /(d\/c|\bdc\b)/i pattern
+    // matched the mid-title "DC" and silently dropped this boarding all day.
+    const { skip } = applyDetailFilters(
+      validBoarding({ service_type: 'Boarding discounted nights for DC full-time' }),
+      'Boarding discounted nights for DC full-time',
     );
     expect(skip).toBe(false);
   });

--- a/src/__tests__/scraper/syncRunner.test.js
+++ b/src/__tests__/scraper/syncRunner.test.js
@@ -262,6 +262,49 @@ describe('runScheduleSync', () => {
     expect(enqueue).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ external_id: 'C63QgJQ9' }));
     expect(result.skipped).toBe(0);
   });
+
+  it('enqueues "Boarding discounted nights for DC full-time" — mid-title DC must not be filtered', async () => {
+    // Regression: C63QghzF (Peanut, Leo Garver, May 1–5 2026). The service name
+    // "Boarding discounted nights for DC full-time" contains "DC" as a client tier
+    // descriptor. The old /(d\/c|\bdc\b)/i pattern matched the mid-title "DC" word
+    // and silently dropped this overnight boarding all day. Fix: anchor to ^(d\/c|dc)\b.
+    ensureSession.mockResolvedValue('session=abc');
+    setSession.mockReturnValue(undefined);
+    const html = `
+      <a href="/schedule/a/C63QghzF/1777629600" class="day-event">
+        <span class="day-event-title">Boarding discounted nights for DC full-time</span>
+        <span class="event-pet" data-pet="138053">Peanut</span>
+      </a>
+    `;
+    authenticatedFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(html),
+    });
+    const { enqueue } = await import('../../lib/scraper/syncQueue.js');
+    enqueue.mockResolvedValue(undefined);
+    const supabase = {
+      from: (table) => {
+        if (table === 'sync_settings') {
+          return {
+            select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: { id: '1', schedule_cursor_date: '2026-03-01' }, error: null }) }) }),
+            update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+            insert: () => Promise.resolve({ error: null }),
+          };
+        }
+        return {
+          select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: null, error: null }) }) }),
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+          insert: () => Promise.resolve({ error: null }),
+        };
+      },
+    };
+    getQueueDepth.mockResolvedValue(0);
+    const result = await runScheduleSync(supabase);
+    expect(result.action).toBe('ok');
+    expect(result.found).toBe(1);
+    expect(enqueue).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ external_id: 'C63QghzF' }));
+    expect(result.skipped).toBe(0);
+  });
 });
 
 // ─── runDetailSync — key branches ─────────────────────────────────────────────

--- a/src/lib/scraper/config.js
+++ b/src/lib/scraper/config.js
@@ -20,8 +20,12 @@ export const SCRAPER_CONFIG = {
   // pack group BOARDING appointments with Boarding (Nights) pricing — they pass
   // the pricing filter correctly. PG daycare-only events are caught by the pricing
   // filter (all line items match /pack/i dayServicePatterns).
+  //
+  // NOTE: DC/D/C is anchored to start-of-title. Titles starting with "Boarding"
+  // may reference a "DC full-time" client tier in the service name (e.g.,
+  // "Boarding discounted nights for DC full-time") — those must not be filtered.
   nonBoardingPatterns: [
-    /(d\/c|\bdc\b)/i,
+    /^(d\/c|dc)\b/i,
     /\badd\b/i,
     /switch\s+day/i,
     /back\s+to\s+\d+/i,

--- a/src/lib/scraper/syncRunner.js
+++ b/src/lib/scraper/syncRunner.js
@@ -315,7 +315,7 @@ export async function runScheduleSync(supabase) {
     const matchedPattern = SCRAPER_CONFIG.nonBoardingPatterns.find(re => re.test(titleLower));
 
     if (matchedPattern) {
-      console.log(`[SyncRunner:Schedule] ⏭️ SKIP ${appt.id} — matched nonBoardingPatterns ${matchedPattern}`);
+      console.log(`[SyncRunner:Schedule] ⏭️ SKIP ${appt.id} title="${appt.title}" — matched nonBoardingPatterns ${matchedPattern}`);
       stats.skipped++;
       continue;
     }


### PR DESCRIPTION
## Summary

- `nonBoardingPatterns`: change `/(d\/c|\bdc\b)/i` → `/^(d\/c|dc)\b/i` (start-of-title anchor)
- `syncRunner.js`: log the appointment title on SKIP (was omitted — blind spot in diagnosis)
- 2 new regression tests (appointmentFilter + syncRunner)

## Root cause

The old `\bdc\b` pattern matched `DC` as a standalone word **anywhere** in the title. Service name "Boarding discounted nights for DC full-time" uses "DC full-time" as a client membership tier, not an appointment type. Every real daycare title starts with "D/C" or "DC" — the false positive comes from a mid-title tier reference on a boarding service.

**Confirmed instance:** Peanut (Leo Garver, May 1–5 2026, C63QghzF). Skipped in every scan all day. Never entered DB. Zero WhatsApp notifications sent.

## Test plan
- [x] `appointmentFilter.test.js`: "Boarding discounted nights for DC full-time" → `skip: false`
- [x] `syncRunner.test.js`: C63QghzF with that title → enqueued, not skipped
- [x] Existing "skips DC:FT" and "skips D/C M/T/W/TH" tests still pass (start-of-title anchor still catches them)
- [x] 1045 tests, 0 failures

## After merge

Manually trigger the **Integration Check** workflow via `workflow_dispatch` — Step 0 will re-run the sync, C63QghzF will be enqueued, and `cron-detail` will process it within minutes. Or wait for the midnight cron.
