### PR TITLE
fix: suppress PT daycare false positives in integration check (#200)

### DIFF
--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -320,10 +320,19 @@ async function extractNamesFromScreenshot(client, screenshotBuffer) {
           {
             type: 'text',
             text: `This is a screenshot of a dog boarding facility's weekly schedule page.
-List every BOARDING appointment you can see. Skip daycare (DC), pack group (PG), and other non-boarding events.
-For each boarding, extract the dog's name — it's the first word in the appointment title, before any date or parenthetical.
+
+Identify ONLY overnight boarding appointments — stays where the dog sleeps at the facility for multiple nights. Their titles show multi-day date ranges like "5/7-15 (Fri)", "5/8-11 (Mon)", or "Boarding (Nights)". Pack-group boardings may appear as "PG 3/23-30".
+
+Do NOT include:
+- Daycare (DC, D/C) — single-day visits
+- Pack Group daycare (PG, P/G with day codes like FT, M/T/W/TH) — recurring single-day
+- Part-Time daycare (PT: T.W.TH, PT FT) — recurring single-day
+- Pick-Up (P/U) entries — daytime transport to/from daycare, not overnight boarding
+- Drop-Off entries — daytime transport, not overnight boarding
+
+For each overnight boarding, extract the dog's name — it appears in the appointment title or as a pet label, before any date or parenthetical.
 Return ONLY a valid JSON array of name strings. Example: ["Buddy", "Goose", "Max"]
-If you see no boardings, return: []`,
+If you see no overnight boardings, return: []`,
           },
         ],
       },

--- a/src/__tests__/scraper/appointmentFilter.test.js
+++ b/src/__tests__/scraper/appointmentFilter.test.js
@@ -14,6 +14,7 @@ vi.mock('../../lib/scraper/config.js', () => ({
   SCRAPER_CONFIG: {
     nonBoardingPatterns: [
       /^(d\/c|dc)\b/i,
+      /^PT\b/i,
       /\badd\b/i,
       /switch\s+day/i,
       /back\s+to\s+\d+/i,
@@ -91,6 +92,18 @@ describe('title filter', () => {
       validBoarding({ service_type: 'PG 3/23-30' }), 'PG 3/23-30',
     );
     expect(skip).toBe(false);
+  });
+
+  it('skips "PT: T.W.TH" — Part-Time daycare title must not be treated as boarding', () => {
+    // Regression: C63QgiVF (Maverick, May 4 2026). "PT: T.W.TH" is a recurring
+    // Part-Time daycare appointment that uses the /schedule/a/ URL format but is
+    // never an overnight stay. Missing ^PT\b caused false "Missing from DB" alerts
+    // on every integration check run when the appointment was visible on the schedule.
+    const { skip, reason } = applyDetailFilters(
+      validBoarding({ service_type: 'PT: T.W.TH' }), 'PT: T.W.TH',
+    );
+    expect(skip).toBe(true);
+    expect(reason).toMatch(/title_pattern/);
   });
 
   it('does NOT skip "Boarding discounted nights for DC full-time" — DC mid-title is a pricing tier, not daycare', () => {

--- a/src/__tests__/scraper/syncRunner.test.js
+++ b/src/__tests__/scraper/syncRunner.test.js
@@ -305,6 +305,48 @@ describe('runScheduleSync', () => {
     expect(enqueue).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ external_id: 'C63QghzF' }));
     expect(result.skipped).toBe(0);
   });
+
+  it('skips "PT: T.W.TH" appointment — Part-Time daycare must not be enqueued as a boarding', async () => {
+    // Regression: C63QgiVF (Maverick, May 4 2026). "PT: T.W.TH" is a recurring
+    // Part-Time daycare appointment using the /schedule/a/ URL format. Missing ^PT\b
+    // in nonBoardingPatterns caused the integration check DOM scanner to flag it as
+    // a boarding candidate and fire false "Missing from DB" alerts every run.
+    ensureSession.mockResolvedValue('session=abc');
+    setSession.mockReturnValue(undefined);
+    const html = `
+      <a href="/schedule/a/C63QgiVF/1777975200" class="day-event">
+        <span class="day-event-title">PT: T.W.TH</span>
+        <span class="event-pet" data-pet="168474">Maverick</span>
+      </a>
+    `;
+    authenticatedFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(html),
+    });
+    const { enqueue } = await import('../../lib/scraper/syncQueue.js');
+    enqueue.mockResolvedValue(undefined);
+    const supabase = {
+      from: (table) => {
+        if (table === 'sync_settings') {
+          return {
+            select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: { id: '1', schedule_cursor_date: '2026-03-01' }, error: null }) }) }),
+            update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+            insert: () => Promise.resolve({ error: null }),
+          };
+        }
+        return {
+          select: () => ({ limit: () => ({ single: () => Promise.resolve({ data: null, error: null }) }) }),
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+          insert: () => Promise.resolve({ error: null }),
+        };
+      },
+    };
+    getQueueDepth.mockResolvedValue(0);
+    const result = await runScheduleSync(supabase);
+    expect(result.action).toBe('ok');
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
 });
 
 // ─── runDetailSync — key branches ─────────────────────────────────────────────

--- a/src/lib/scraper/config.js
+++ b/src/lib/scraper/config.js
@@ -24,8 +24,16 @@ export const SCRAPER_CONFIG = {
   // NOTE: DC/D/C is anchored to start-of-title. Titles starting with "Boarding"
   // may reference a "DC full-time" client tier in the service name (e.g.,
   // "Boarding discounted nights for DC full-time") — those must not be filtered.
+  //
+  // NOTE: PT (Part-Time) is an AGYD daycare tier, not a boarding service. Titles
+  // like "PT: T.W.TH" (recurring Part-Time T/W/TH daycare) use the same
+  // /schedule/a/ URL format as boardings but are never overnight stays. Added
+  // after B-2: C63QgiVF (Maverick) triggered false "Missing from DB" alerts
+  // every run because the integration check DOM scanner saw PT appointments as
+  // boarding candidates.
   nonBoardingPatterns: [
     /^(d\/c|dc)\b/i,
+    /^PT\b/i,
     /\badd\b/i,
     /switch\s+day/i,
     /back\s+to\s+\d+/i,


### PR DESCRIPTION
## Summary

- Fixes two false-positive alert sources that were firing on every integration check run after Anthropic API credits came back online (Step 3 is now active)
- No behavior change for real boardings

## Changes

### 1. `config.js` — add `^PT\b` to `nonBoardingPatterns`

Maverick's recurring "PT: T.W.TH" (Part-Time daycare, T/W/TH) uses the same `/schedule/a/` URL format as boarding appointments. The detail sync correctly classified it as non-boarding on April 30 (status `done`, no boarding row created), but the integration check DOM scanner saw it as a boarding candidate on every subsequent run and fired "Missing from DB: Maverick" each time.

Same class as B-1 (DC anchor). Fix is in the shared config so it propagates to both the sync runner (SKIP log: `⏭️ SKIP C63QgiVF title="PT: T.W.TH" — matched nonBoardingPatterns /^PT\b/i`) and the integration check DOM scanner (`isBoardingTitle` returns false, drops from candidates).

### 2. `integration-check.js` — tighten Claude vision prompt

Step 3 is now running. Claude cited "Pick-Up and Drop-Off entries which indicate boarding stays" and returned 6 false-positive names (Chester, Stephanie, Mabel, Archana, Winston, Lucy). Verified: Chester/Stephanie/Archana/Winston aren't in the `dogs` table at all; Mabel's last boarding was Oct 2024, Lucy's March 2026.

Prompt now explicitly names P/U and Drop-Off as daytime transport (not boarding) and defines what a boarding title looks like (multi-day date ranges).

### 3. Tests

- `appointmentFilter.test.js` — mock updated to include `/^PT\b/i`; regression test: `"PT: T.W.TH"` → `skip: true`, `reason` matches `title_pattern`
- `syncRunner.test.js` — regression test: `C63QgiVF "PT: T.W.TH"` → `enqueue` not called, `skipped: 1`

**1047 tests, 0 failures** (up from 1045)

## Test plan

- [ ] CI passes
- [ ] Merge → verify next integration check run (any of the 3 daily runs) shows no "Missing from DB: Maverick" and no Claude false positives for the 6 daytime dogs
