### PR TITLE
fix: remove Claude vision check from integration check (#202)

### DIFF
--- a/.github/workflows/integration-check.yml
+++ b/.github/workflows/integration-check.yml
@@ -1,4 +1,4 @@
-# Integration check — scrapes the AGYD schedule via real browser + Claude vision,
+# Integration check — scrapes the AGYD schedule via real browser (Playwright),
 # compares against DB, sends WhatsApp report.
 #
 # Step 0 runs schedule sync + drains detail queue before the Playwright compare,
@@ -13,7 +13,6 @@
 # Required Repository secrets (Settings → Secrets → Actions → Repository secrets):
 #   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 #   EXTERNAL_SITE_USERNAME, EXTERNAL_SITE_PASSWORD  ← Step 0 re-auth on session expiry
-#   ANTHROPIC_API_KEY
 #   META_PHONE_NUMBER_ID, META_WHATSAPP_TOKEN
 #   INTEGRATION_CHECK_RECIPIENTS  ← separate from NOTIFY_RECIPIENTS (Kate only)
 name: Integration Check
@@ -53,7 +52,6 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           EXTERNAL_SITE_USERNAME: ${{ secrets.EXTERNAL_SITE_USERNAME }}
           EXTERNAL_SITE_PASSWORD: ${{ secrets.EXTERNAL_SITE_PASSWORD }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           META_PHONE_NUMBER_ID: ${{ secrets.META_PHONE_NUMBER_ID }}
           META_WHATSAPP_TOKEN: ${{ secrets.META_WHATSAPP_TOKEN }}
           INTEGRATION_CHECK_RECIPIENTS: ${{ secrets.INTEGRATION_CHECK_RECIPIENTS }}

--- a/docs/job_docs/integration-check.md
+++ b/docs/job_docs/integration-check.md
@@ -17,12 +17,11 @@ In short: **Playwright + Claude see what a human sees. The DB sees what the sync
 
 The nightly sync cron (`cron-schedule.js` + `cron-detail.js`) runs at midnight UTC. If it fails silently — bad session, network error, parse bug — boardings go missing from the DB. There's currently no alert for that. You'd only notice when a dog shows up that nobody knew about.
 
-The integration check is that alert. It uses two signal paths that are completely independent from the sync pipeline:
+The integration check is that alert. It uses a signal path completely independent from the sync pipeline:
 
-1. **Playwright DOM extraction** — renders the AGYD schedule page in a real browser, reads the rendered DOM. Different execution environment and code path from the regex-based HTML parser the cron uses.
-2. **Claude vision** — reads a screenshot of the page the way a human would, pixel-level, no DOM parsing at all.
+**Playwright DOM extraction** — renders the AGYD schedule page in a real browser, reads the rendered DOM. Different execution environment and code path from the regex-based HTML parser the cron uses.
 
-If either signal sees something the DB doesn't have → WhatsApp to Kate.
+If Playwright sees something the DB doesn't have → WhatsApp to Kate.
 
 ---
 
@@ -36,7 +35,7 @@ Runs the schedule sync and drains the detail queue **before** the Playwright com
 - `resetStuck` is called once before the loop, not on every iteration (avoids 20 redundant DB queries)
 - **Non-fatal** — if Step 0 throws for any reason (session expired and no credentials configured, network error), the error is logged and the check continues to Step 1 with whatever is currently in the DB
 - Does NOT call `writeCronHealth` — health tracking is the Vercel cron handlers' responsibility. Step 0 is a "best effort" sync, not a scheduled cron run.
-- Signal isolation is preserved: Steps 2–5 (Playwright, Claude, DB compare) are unchanged and import nothing from `src/lib/scraper/`. Step 0 runs before the independent check begins.
+- Signal isolation is preserved: Steps 2–4 (Playwright, DB compare) are unchanged and import nothing from `src/lib/scraper/`. Step 0 runs before the independent check begins.
 
 **Session re-auth in Step 0:** `ensureSession` can re-authenticate if the session is expired, provided `EXTERNAL_SITE_USERNAME` and `EXTERNAL_SITE_PASSWORD` are set as GH repo secrets. If they are, a stale session will be refreshed and the fresh session is available to Step 1's `loadSession` (making Playwright work too). If they're not set, re-auth silently fails and Step 0 is skipped.
 
@@ -53,10 +52,7 @@ Reads `session_cookies` from `sync_settings` in Supabase — the same auth token
 - Extracts **daytime appointments**: all `<a class="day-event cat-5634 ...">` and `cat-7431` links → list of `{id, catId, dayTs, title, petName}` (DC + PG only)
 - `SCRAPER_CONFIG.nonBoardingPatterns` is imported from `src/lib/scraper/config.js` (shared with the sync pipeline). The independent verification signal is Playwright's live DOM rendering, not a duplicate copy of the filter logic. `DAYTIME_CAT_IDS` is still defined locally.
 
-### Step 3 — Claude reads the screenshot *(requires Anthropic credits)*
-Sends the PNG to Claude API (claude-sonnet-4-6) with a vision prompt asking it to list every boarding dog name it can see. Returns `string[]`. This is the "what a human would see" signal — entirely independent from any code. Non-fatal: if Claude fails (no credits, API down), the check continues without the name comparison.
-
-### Step 4 — Query the DB
+### Step 3 — Query the DB
 Two queries run in parallel:
 
 **Boardings** — `boardings JOIN dogs` where:
@@ -67,19 +63,16 @@ The lower bound is **7 days ago** so boardings that departed earlier this week (
 
 **Daytime** — `daytime_appointments` where `appointment_date = today` (UTC). Returns `{external_id, service_category, title}`.
 
-### Step 5 — Compare (4 checks)
+### Step 4 — Compare (3 checks)
 
-**Boarding (3 checks):**
+**Boarding (2 checks):**
 1. **Missing from DB** — any schedule appointment ID from Playwright not found in DB → `"Missing from DB: Buddy — 3/16-19 (C63QgY32)"`. Format is `"{petName} — {title} ({id})"` when a pet name is available, otherwise falls back to just `"{title} ({id})"`.
 2. **Unknown dog name** — any DB boarding in the window with `dog_name = 'Unknown'` → "Unknown dog name in DB: {id}"
-3. **Claude name mismatch** — any name Claude sees that doesn't match any DB boarding name → "Claude sees '{name}' but no DB boarding matches"
-   - Only runs when Claude returned names (skipped if Claude failed)
-   - Known limitation: compares first-word names ("Buddy Jr." in DB won't match "Buddy" from Claude)
 
 **Daytime (1 check — smoke test):**
-4. **Daytime missing from DB** — DOM events in today's column (filtered by `dayTs`) not found in DB by `external_id` → `"Daytime missing from DB: Buddy — D/C FT (C63QgY4U)"`. Same `petName — title (id)` format as boarding.
+3. **Daytime missing from DB** — DOM events in today's column (filtered by `dayTs`) not found in DB by `external_id` → `"Daytime missing from DB: Buddy — D/C FT (C63QgY4U)"`. Same `petName — title (id)` format as boarding.
 
-### Step 6 — WhatsApp report + exit
+### Step 5 — WhatsApp report + exit
 Sends to `INTEGRATION_CHECK_RECIPIENTS` (Kate only — separate from `NOTIFY_RECIPIENTS` which goes to the whole team). Two-section text:
 - ✅ Pass:
   ```
@@ -108,8 +101,6 @@ Sends to `INTEGRATION_CHECK_RECIPIENTS` (Kate only — separate from `NOTIFY_REC
 | **Past-week departures still visible on schedule** | DB query uses 7-days-ago as lower bound. The AGYD schedule page shows ~2 weeks. If you narrow the lower bound to midnight today, past-departed boardings still on the page will be falsely flagged as missing |
 | **NON_BOARDING_PATTERNS must be case-insensitive** | `ADD` is uppercase on the schedule. `/\badd\b/i` not `/\badd\b/`. Same fix needed in `cron-schedule.js` |
 | **NON_BOARDING_PATTERNS are shared, not duplicated** | `integration-check.js` imports `SCRAPER_CONFIG.nonBoardingPatterns` from `src/lib/scraper/config.js`. Signal isolation is at the scraping level (Playwright DOM vs regex HTML parser), not the filter level. Updating `config.js` automatically applies to the integration check. |
-| **Claude name check is fuzzy** | Claude returns first-word names from appointment titles. A dog named "Buddy Jr." will always trigger a false positive. This is acceptable for a smoke test |
-| **Claude is non-fatal** | If Claude API fails or returns unparseable output, Check 3 is skipped. Checks 1 and 2 still run. The report will still be sent |
 | **Playwright downloads ~280MB of Chromium** | Cached by GH Actions after first run. If the cache is cold the job takes ~5 minutes |
 | **GH Actions secrets vs Vercel env vars** | These are separate. Adding something to Vercel doesn't make it available in GH Actions. All secrets in the workflow must also be added as **Repository secrets** in GitHub (NOT environment secrets — the workflows don't declare `environment:`) |
 
@@ -117,14 +108,8 @@ Sends to `INTEGRATION_CHECK_RECIPIENTS` (Kate only — separate from `NOTIFY_REC
 
 ## What It Still Needs
 
-### Claude credits
-Step 3 silently skips when the Anthropic API key has no credits. A `::warning::` annotation fires in the GH Actions log (line 621 of `integration-check.js`). Checks 1 and 2 still run and the report is still sent. This is accepted behavior — K-5 closed May 1, 2026. Top up at console.anthropic.com → Plans & Billing if you want the name-mismatch check restored.
-
 ### Multi-week schedule coverage
 Playwright scrapes the current week's schedule page only. Boardings starting next week won't appear in Playwright's scrape but will be in the DB query window. This means the boarding ID check only catches *this week's* missing boardings. Widening would require fetching a second schedule page.
-
-### Claude name comparison is fragile for multi-word names
-`"Buddy Jr."` in the DB won't match `"Buddy"` from Claude. Currently logged as a warning, not a hard failure. Could be improved by fuzzy matching (startsWith, or checking if DB name starts with the Claude name).
 
 ---
 
@@ -138,7 +123,6 @@ All must be **Repository secrets** in GitHub (Settings → Secrets → Actions �
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role key — bypasses RLS | Supabase project settings → API → Secret keys |
 | `EXTERNAL_SITE_USERNAME` | AGYD login email — Step 0 re-auth | Copy from Vercel env vars |
 | `EXTERNAL_SITE_PASSWORD` | AGYD login password — Step 0 re-auth | Copy from Vercel env vars |
-| `ANTHROPIC_API_KEY` | Claude API key | console.anthropic.com → API Keys |
 | `META_PHONE_NUMBER_ID` | Meta sender phone number ID | Meta app dashboard |
 | `META_WHATSAPP_TOKEN` | Meta system user access token | Meta app dashboard |
 | `INTEGRATION_CHECK_RECIPIENTS` | Kate's phone number only (E.164) | Manually set — NOT from Vercel |
@@ -184,9 +168,8 @@ The check uses Playwright (headless Chromium, ~280MB) and runs for ~1 minute. Ve
 These will look like issues but aren't:
 
 1. **`ADD *` appointments** — filtered by `NON_BOARDING_PATTERNS` with `i` flag
-2. **Multi-word dog names vs Claude first-word extraction** — by design, low-priority (e.g. "Buddy Jr." in DB won't match "Buddy" from Claude)
-3. **No boardings this week** — passes with "0 in DB — all match schedule" which is correct
-4. **No daytime events today** — passes with "0 on schedule, 0 in DB — all good" which is correct
-5. **DB daytime count > DOM count** — the DB may have stale records from previous syncs for appointments that were removed from the AGYD schedule. The daytime check only flags DOM→DB misses, not DB→DOM misses, so these don't trigger alerts.
-6. **Canceled/pending booking requests** — AGYD shows booking requests on the schedule DOM even when the client submitted a request that was never confirmed (`booking_status='canceled'`) or is still pending. The sync pipeline (Layer 3b in sync.js) correctly skips canceled ones. The integration check cannot detect cancellation status without fetching every detail page (too slow), so these appear as "Missing from DB" false positives. If you see a missing boarding alert for a dog you know had a canceled or unconfirmed request, this is why.
-7. **`N/C *` titles (new client initial evaluations)** — "N/C" prefix means the dog is a new client doing an Initial Evaluation daytime visit (never an overnight boarding). The sync pipeline correctly excludes these via the detail-page `service_type` ("Initial Evaluation" matches `/initial\s+eval/i` in `nonBoardingPatterns`). The integration check only sees the schedule title (e.g. "N/C Tula 3/23-26") and filters it via `DAYCARE_ONLY_PATTERNS`. Confirmed by business owner: N/C prefix is never used on overnight boardings.
+2. **No boardings this week** — passes with "0 in DB — all match schedule" which is correct
+3. **No daytime events today** — passes with "0 on schedule, 0 in DB — all good" which is correct
+4. **DB daytime count > DOM count** — the DB may have stale records from previous syncs for appointments that were removed from the AGYD schedule. The daytime check only flags DOM→DB misses, not DB→DOM misses, so these don't trigger alerts.
+5. **Canceled/pending booking requests** — AGYD shows booking requests on the schedule DOM even when the client submitted a request that was never confirmed (`booking_status='canceled'`) or is still pending. The sync pipeline (Layer 3b in sync.js) correctly skips canceled ones. The integration check cannot detect cancellation status without fetching every detail page (too slow), so these appear as "Missing from DB" false positives. If you see a missing boarding alert for a dog you know had a canceled or unconfirmed request, this is why.
+6. **`N/C *` titles (new client initial evaluations)** — "N/C" prefix means the dog is a new client doing an Initial Evaluation daytime visit (never an overnight boarding). The sync pipeline correctly excludes these via the detail-page `service_type` ("Initial Evaluation" matches `/initial\s+eval/i` in `nonBoardingPatterns`). The integration check only sees the schedule title (e.g. "N/C Tula 3/23-26") and filters it via `DAYCARE_ONLY_PATTERNS`. Confirmed by business owner: N/C prefix is never used on overnight boardings.

--- a/scripts/integration-check.js
+++ b/scripts/integration-check.js
@@ -9,9 +9,6 @@
  *
  *   1. Playwright renders the schedule page in a real browser, then
  *      document.querySelectorAll reads the live DOM — no regex, no raw HTML.
- *   2. Claude API (vision) reads a screenshot the way a human would —
- *      pixel-level, no DOM parsing at all.
- *
  *   Both signals are compared against the DB to catch bugs the sync pipeline
  *   cannot catch about itself.
  *
@@ -26,25 +23,22 @@
  *      bookings added since the midnight cron are in the DB before we compare.
  *      Non-fatal — if sync fails, the check continues with the current DB state.
  *   1. Load session cookies from Supabase sync_settings (same cache the crons use)
- *   2. Playwright: render /schedule, take screenshot + extract appointment IDs
+ *   2. Playwright: render /schedule, extract appointment IDs
  *      from live DOM links (boarding + daytime)
- *   3. Claude API: read screenshot → list dog names visible on the page
- *   4. Supabase: query boardings overlapping today → today+7d; query daytime_appointments for today
- *   5. Compare → flag missing IDs, Unknown dog names, name mismatches (boarding);
+ *   3. Supabase: query boardings overlapping today → today+7d; query daytime_appointments for today
+ *   4. Compare → flag missing IDs, Unknown dog names (boarding);
  *      flag missing daytime events (daytime smoke check)
- *   6. Send WhatsApp text report to INTEGRATION_CHECK_RECIPIENTS (separate from
+ *   5. Send WhatsApp text report to INTEGRATION_CHECK_RECIPIENTS (separate from
  *      the roster NOTIFY_RECIPIENTS — this is a technical report for Kate only)
  *
  * Required env vars (GitHub Actions Repository secrets):
  *   VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
  *   EXTERNAL_SITE_USERNAME, EXTERNAL_SITE_PASSWORD  (for Step 0 re-auth on session expiry)
- *   ANTHROPIC_API_KEY
  *   META_PHONE_NUMBER_ID, META_WHATSAPP_TOKEN
  *   INTEGRATION_CHECK_RECIPIENTS  (separate from NOTIFY_RECIPIENTS)
  */
 
 import { chromium } from 'playwright';
-import Anthropic from '@anthropic-ai/sdk';
 import { createClient } from '@supabase/supabase-js';
 import { sendTextMessage, getAlertRecipients } from '../src/lib/notifyWhatsApp.js';
 import { recordSentMessages, recordMessageLog } from '../src/lib/messageDeliveryStatus.js';
@@ -126,12 +120,6 @@ function getSupabase() {
   return createClient(url, key);
 }
 
-function getAnthropicClient() {
-  const key = process.env.ANTHROPIC_API_KEY;
-  if (!key) throw new Error('Missing ANTHROPIC_API_KEY');
-  return new Anthropic({ apiKey: key });
-}
-
 // ---------------------------------------------------------------------------
 // Step 1: Load session cookies from Supabase
 // ---------------------------------------------------------------------------
@@ -191,14 +179,13 @@ function parseCookieString(raw, domain) {
 
 /**
  * Render the schedule page in a headless Chromium browser and return:
- *   - screenshot: Buffer (PNG) — for Claude vision
  *   - boardingAppointments: Array<{id, title}> — boarding candidates from live DOM
  *   - daytimeAppointments: Array<{id, catId, dayTs, title}> — DC/PG events from live DOM
  *
  * Signal independence: document.querySelectorAll reads the rendered DOM after
  * JavaScript execution — completely different from regex on raw server HTML.
  *
- * Browser is always closed via try/finally, even if screenshot or evaluate throws.
+ * Browser is always closed via try/finally, even if evaluate throws.
  */
 async function scrapeWithPlaywright(cookieString) {
   console.log('[IntegCheck] Launching headless Chromium...');
@@ -226,10 +213,6 @@ async function scrapeWithPlaywright(cookieString) {
     if (isLoginPage > 0) {
       throw new Error('SESSION_REJECTED — AGYD served login page. Run cron-auth to refresh session.');
     }
-
-    console.log('[IntegCheck] Taking full-page screenshot...');
-    const screenshot = await page.screenshot({ fullPage: true });
-    console.log('[IntegCheck] Screenshot: %d bytes', screenshot.length);
 
     // Extract appointment IDs + titles from rendered DOM.
     // Boarding: schedule/a/ links. Daytime: .day-event links with cat-{id} class.
@@ -278,98 +261,15 @@ async function scrapeWithPlaywright(cookieString) {
     );
     console.log('[IntegCheck] DOM daytime events: %d DC/PG events extracted', daytimeAppointments.length);
 
-    return { screenshot, boardingAppointments, daytimeAppointments };
+    return { boardingAppointments, daytimeAppointments };
   } finally {
-    // Always close the browser — even if screenshot or evaluate threw.
+    // Always close the browser — even if evaluate threw.
     await browser.close();
   }
 }
 
 // ---------------------------------------------------------------------------
-// Step 3: Claude vision — read dog names from screenshot
-// ---------------------------------------------------------------------------
-
-/**
- * Ask Claude to identify every boarding appointment visible in the screenshot.
- * Claude reads pixels — no DOM parsing, no regex — fully independent signal.
- *
- * Returns dog names Claude sees on the page. Cross-checked against DB names
- * to catch cases where the sync stored a wrong or "Unknown" name.
- *
- * Response is validated to be string[] before returning — Claude occasionally
- * returns mixed types (numbers, null) that would crash .toLowerCase() downstream.
- */
-async function extractNamesFromScreenshot(client, screenshotBuffer) {
-  console.log('[IntegCheck] Sending screenshot to Claude for visual name extraction...');
-
-  const message = await client.messages.create({
-    model: 'claude-sonnet-4-6',
-    max_tokens: 1024,
-    messages: [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'image',
-            source: {
-              type: 'base64',
-              media_type: 'image/png',
-              data: screenshotBuffer.toString('base64'),
-            },
-          },
-          {
-            type: 'text',
-            text: `This is a screenshot of a dog boarding facility's weekly schedule page.
-
-Identify ONLY overnight boarding appointments — stays where the dog sleeps at the facility for multiple nights. Their titles show multi-day date ranges like "5/7-15 (Fri)", "5/8-11 (Mon)", or "Boarding (Nights)". Pack-group boardings may appear as "PG 3/23-30".
-
-Do NOT include:
-- Daycare (DC, D/C) — single-day visits
-- Pack Group daycare (PG, P/G with day codes like FT, M/T/W/TH) — recurring single-day
-- Part-Time daycare (PT: T.W.TH, PT FT) — recurring single-day
-- Pick-Up (P/U) entries — daytime transport to/from daycare, not overnight boarding
-- Drop-Off entries — daytime transport, not overnight boarding
-
-For each overnight boarding, extract the dog's name — it appears in the appointment title or as a pet label, before any date or parenthetical.
-Return ONLY a valid JSON array of name strings. Example: ["Buddy", "Goose", "Max"]
-If you see no overnight boardings, return: []`,
-          },
-        ],
-      },
-    ],
-  });
-
-  const raw = message.content[0].text.trim();
-  console.log('[IntegCheck] Claude raw response: %s', raw);
-
-  try {
-    const match = raw.match(/\[[\s\S]*\]/);
-    const parsed = match ? JSON.parse(match[0]) : [];
-
-    // Validate every element is a non-empty string. Claude occasionally returns
-    // numbers or null in the array, which would crash .toLowerCase() in compareResults.
-    const names = Array.isArray(parsed)
-      ? parsed.filter(n => typeof n === 'string' && n.trim().length > 0)
-      : [];
-
-    if (names.length !== (Array.isArray(parsed) ? parsed.length : 0)) {
-      console.warn(
-        '[IntegCheck] Claude response contained %d non-string/empty entries — filtered out (raw: %s)',
-        (Array.isArray(parsed) ? parsed.length : 0) - names.length,
-        raw.slice(0, 200),
-      );
-    }
-
-    console.log('[IntegCheck] Claude identified %d dog name(s): %s', names.length, names.join(', ') || '(none)');
-    return names;
-  } catch (err) {
-    console.error('[IntegCheck] Failed to parse Claude response as JSON: %s (raw: %s)', err.message, raw.slice(0, 200));
-    return [];
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Step 4: Query DB
+// Step 3: Query DB
 // ---------------------------------------------------------------------------
 
 async function queryDbBoardings(supabase) {
@@ -428,20 +328,13 @@ async function queryDbDaytimeAppointments(supabase) {
 // ---------------------------------------------------------------------------
 
 /**
- * Three checks:
+ * Two checks:
  *   1. Schedule IDs missing from DB — scraped but never synced
  *   2. DB boardings with "Unknown" dog name — name extraction failed during sync
- *   3. Claude sees a name not present in any DB boarding — name mismatch
- *      (only flagged when Claude returned names; skipped on empty schedule)
- *
- * Known limitation: Check 3 compares first-word names (Claude) against full
- * DB names (lowercase). "Buddy Jr." in DB won't match "Buddy" from Claude —
- * this is an acceptable false positive rate for a smoke test.
  */
-function compareResults(scraped, claudeNames, dbBoardings) {
+function compareResults(scraped, dbBoardings) {
   const issues = [];
   const dbIds = new Set(dbBoardings.map(b => b.external_id).filter(Boolean));
-  const dbNamesLower = new Set(dbBoardings.map(b => b.dog_name.toLowerCase()));
 
   // Check 1: IDs on schedule not in DB
   for (const appt of scraped) {
@@ -458,16 +351,6 @@ function compareResults(scraped, claudeNames, dbBoardings) {
   for (const b of dbBoardings.filter(b => b.dog_name === 'Unknown')) {
     console.log('[IntegCheck] ⚠️  Unknown dog in DB: external_id=%s', b.external_id);
     issues.push(`Unknown dog name in DB: ${b.external_id ?? '(no external_id)'}`);
-  }
-
-  // Check 3: Claude sees a name the DB doesn't have
-  if (claudeNames.length > 0) {
-    for (const name of claudeNames) {
-      if (!dbNamesLower.has(name.toLowerCase())) {
-        console.log('[IntegCheck] ⚠️  Claude sees "%s" on schedule but no DB boarding matches', name);
-        issues.push(`Claude sees "${name}" on schedule but no DB boarding matches`);
-      }
-    }
   }
 
   const passed = issues.length === 0;
@@ -542,10 +425,9 @@ async function main() {
 
   const today = new Date().toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' });
 
-  let supabase, anthropic;
+  let supabase;
   try {
     supabase = getSupabase();
-    anthropic = getAnthropicClient();
   } catch (err) {
     const msg = `⚠️ Integration check crashed at startup (${today}): ${err.message}`;
     console.error('[IntegCheck]', msg);
@@ -611,9 +493,9 @@ async function main() {
   }
 
   // Step 2: Playwright
-  let screenshot, boardingAppointments, daytimeAppointments;
+  let boardingAppointments, daytimeAppointments;
   try {
-    ({ screenshot, boardingAppointments, daytimeAppointments } = await scrapeWithPlaywright(cookieString));
+    ({ boardingAppointments, daytimeAppointments } = await scrapeWithPlaywright(cookieString));
   } catch (err) {
     const msg = `⚠️ Integration check failed (${today})\nPlaywright error: ${err.message}`;
     console.error('[IntegCheck]', msg);
@@ -621,28 +503,19 @@ async function main() {
     process.exit(1);
   }
 
-  // Step 3: Claude vision (non-fatal — continue without it if API is down)
-  let claudeNames = [];
-  try {
-    claudeNames = await extractNamesFromScreenshot(anthropic, screenshot);
-  } catch (err) {
-    console.error('[IntegCheck] Claude vision failed (skipping name check): %s', err.message);
-    console.log(`::warning::Integration check Step 3 (Claude vision) skipped — ${err.message}`);
-  }
-
-  // Step 4: DB — boarding + daytime in parallel
+  // Step 3: DB — boarding + daytime in parallel
   const [dbBoardings, dbDaytime] = await Promise.all([
     queryDbBoardings(supabase),
     queryDbDaytimeAppointments(supabase),
   ]);
 
-  // Step 5: Compare
-  const { passed: boardingPassed, issues: boardingIssues } = compareResults(boardingAppointments, claudeNames, dbBoardings);
+  // Step 4: Compare
+  const { passed: boardingPassed, issues: boardingIssues } = compareResults(boardingAppointments, dbBoardings);
   const { passed: daytimePassed, issues: daytimeIssues, domCount, dbCount } = compareDaytimeResults(daytimeAppointments, dbDaytime);
   const passed = boardingPassed && daytimePassed;
   const allIssues = [...boardingIssues, ...daytimeIssues];
 
-  // Step 6: Report
+  // Step 5: Report
   const bn = dbBoardings.length;
   let message;
   if (passed) {


### PR DESCRIPTION
## Summary
- Removes `extractNamesFromScreenshot()` (Claude vision / Check 3) entirely from `scripts/integration-check.js`
- Check 1 (Playwright DOM ID match) is the reliable signal — Check 3 added false positives on every run with no signal Check 1 doesn't already provide
- Removes `Anthropic` import, `getAnthropicClient()`, the screenshot capture from Playwright, and `ANTHROPIC_API_KEY` from the workflow env block
- `compareResults()` now takes 2 args instead of 3; doc updated to reflect 2 boarding checks + 1 daytime check

## Test plan
- [x] 1047 tests, 0 failures
- [ ] Trigger manual `workflow_dispatch` on integration-check.yml after merge — confirm no WhatsApp fires for the client-name false positives that were triggering before
