### PR TITLE
feat: re-sync AGYD appointments modified after initial sync (#204)

### DIFF
--- a/src/__tests__/scraper/syncQueue.test.js
+++ b/src/__tests__/scraper/syncQueue.test.js
@@ -160,10 +160,12 @@ describe('REQ-109: enqueue()', () => {
     expect(supabase._rows).toHaveLength(1);
   });
 
-  it('skips silently when item is done', async () => {
-    const supabase = createMockSupabase([makeItem({ external_id: 'AAA', status: 'done' })]);
-    await enqueue(supabase, { external_id: 'AAA', source_url: 'https://example.com/a/AAA/1' });
+  it('skips silently when item is done and source_url is unchanged', async () => {
+    const url = 'https://agirlandyourdog.com/schedule/a/AAA/1778666400';
+    const supabase = createMockSupabase([makeItem({ external_id: 'AAA', status: 'done', source_url: url })]);
+    await enqueue(supabase, { external_id: 'AAA', source_url: url });
     expect(supabase._rows).toHaveLength(1);
+    expect(supabase._rows[0].status).toBe('done');
   });
 
   it('re-queues a permanently-failed item (resets retry_count to 0)', async () => {
@@ -173,6 +175,42 @@ describe('REQ-109: enqueue()', () => {
     expect(row.status).toBe('pending');
     expect(row.retry_count).toBe(0);
     expect(row.last_error).toBeNull();
+  });
+
+  // B-3: re-sync appointments modified on AGYD after initial sync
+  it('B-3: re-queues done item when source_url timestamp changes (rescheduled appointment)', async () => {
+    const oldUrl = 'https://agirlandyourdog.com/schedule/a/C63QghzH/1778666400';
+    const newUrl = 'https://agirlandyourdog.com/schedule/a/C63QghzH/1778752800';
+    const supabase = createMockSupabase([makeItem({ id: 'id-done', external_id: 'AAA', status: 'done', source_url: oldUrl })]);
+    await enqueue(supabase, { external_id: 'AAA', source_url: newUrl });
+    const row = supabase._rows[0];
+    expect(row.status).toBe('pending');
+    expect(row.source_url).toBe(newUrl);
+    expect(row.retry_count).toBe(0);
+  });
+
+  it('B-3: does not re-queue pending item even when source_url changes', async () => {
+    const oldUrl = 'https://agirlandyourdog.com/schedule/a/AAA/1778666400';
+    const newUrl = 'https://agirlandyourdog.com/schedule/a/AAA/1778752800';
+    const supabase = createMockSupabase([makeItem({ external_id: 'AAA', status: 'pending', source_url: oldUrl })]);
+    await enqueue(supabase, { external_id: 'AAA', source_url: newUrl });
+    expect(supabase._rows[0].status).toBe('pending');
+    expect(supabase._rows[0].source_url).toBe(oldUrl);
+  });
+
+  it('B-3: does not re-queue done item when existing source_url is null (cannot compare)', async () => {
+    const supabase = createMockSupabase([makeItem({ external_id: 'AAA', status: 'done', source_url: null })]);
+    await enqueue(supabase, { external_id: 'AAA', source_url: 'https://agirlandyourdog.com/schedule/a/AAA/1778752800' });
+    expect(supabase._rows[0].status).toBe('done');
+  });
+
+  it('B-3: does not re-queue processing item even when source_url changes', async () => {
+    const oldUrl = 'https://agirlandyourdog.com/schedule/a/AAA/1778666400';
+    const newUrl = 'https://agirlandyourdog.com/schedule/a/AAA/1778752800';
+    const supabase = createMockSupabase([makeItem({ external_id: 'AAA', status: 'processing', source_url: oldUrl })]);
+    await enqueue(supabase, { external_id: 'AAA', source_url: newUrl });
+    expect(supabase._rows[0].status).toBe('processing');
+    expect(supabase._rows[0].source_url).toBe(oldUrl);
   });
 });
 

--- a/src/lib/scraper/syncQueue.js
+++ b/src/lib/scraper/syncQueue.js
@@ -31,7 +31,7 @@ const RETRY_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes per retry_count
 export async function enqueue(supabase, { external_id, source_url, title, type = 'appointment', meta = {}, resetIfDone = false }) {
   const { data: existing, error: fetchError } = await supabase
     .from('sync_queue')
-    .select('id, status')
+    .select('id, status, source_url')
     .eq('external_id', external_id)
     .limit(1)
     .maybeSingle();
@@ -39,12 +39,54 @@ export async function enqueue(supabase, { external_id, source_url, title, type =
   if (fetchError) throw fetchError;
 
   if (existing) {
+    // AGYD embeds the appointment start timestamp in the URL — a URL change means it was rescheduled.
+    // Check before the shouldReset gate so a rescheduled done item is caught without requiring resetIfDone.
+    if (existing.status === 'done' && !resetIfDone) {
+      if (existing.source_url === null) {
+        log(`[SyncQueue] ⚠️ Can't compare URL for ${external_id} — source_url null, skipping modification check`);
+      } else {
+        const incomingTs = source_url.match(/\/(\d+)$/);
+        if (!incomingTs) {
+          log(`[SyncQueue] ⚠️ Incoming URL has no timestamp for ${external_id} — skipping modification check`);
+        } else if (source_url !== existing.source_url) {
+          const oldTsMatch = existing.source_url.match(/\/(\d+)$/);
+          const oldTs = oldTsMatch ? oldTsMatch[1] : '?';
+          const newTs = incomingTs[1];
+          const oldIso = oldTs !== '?' ? new Date(parseInt(oldTs, 10) * 1000).toISOString().slice(0, 10) : '?';
+          const newIso = new Date(parseInt(newTs, 10) * 1000).toISOString().slice(0, 10);
+
+          const { error } = await supabase
+            .from('sync_queue')
+            .update({
+              status: 'pending',
+              retry_count: 0,
+              last_error: null,
+              next_retry_at: null,
+              queued_at: new Date().toISOString(),
+              source_url,
+              type,
+              meta,
+            })
+            .eq('id', existing.id);
+          if (error) throw error;
+          log(`[SyncQueue] 🔄 Re-queued modified appointment: ${external_id} (url changed: /${oldTs} [${oldIso}] → /${newTs} [${newIso}])`);
+          return;
+        }
+      }
+    }
+
+    // Don't disturb in-flight items — log the mismatch so it's auditable but take no action
+    if ((existing.status === 'pending' || existing.status === 'processing') &&
+        existing.source_url !== null && source_url !== existing.source_url) {
+      log(`[SyncQueue] ℹ️ URL mismatch for in-flight item ${external_id} (status: ${existing.status}) — not re-queuing`);
+    }
+
     const shouldReset =
       (existing.status === 'failed') ||
       (existing.status === 'done' && resetIfDone);
 
     if (!shouldReset) {
-      log(`[SyncQueue] ⏭️ Already queued: ${external_id} (status: ${existing.status})`);
+      log(`[SyncQueue] ⏭️ Already queued: ${external_id} (status: ${existing.status}, url: ${existing.source_url})`);
       return;
     }
     // Re-queue a failed item, or a done item when the caller confirmed the result isn't stored yet


### PR DESCRIPTION
## Summary

- `enqueue()` now detects when a `done` appointment was rescheduled on AGYD by comparing the incoming `source_url` against the stored one — AGYD embeds the start timestamp in the URL path, so a URL change is a reliable reschedule signal
- Re-queues the item and updates `source_url` to the new URL; cron-detail picks it up on the next run
- Guards: null `source_url` (pre-dates URL structure), non-timestamp URL format, in-flight (`pending`/`processing`) items are never disturbed
- Log on re-queue decodes both timestamps to ISO dates so the date shift is human-readable without arithmetic

**Confirmed fix for:** Peanut (C63QghzH) — AGYD rescheduled May 13 → May 14 after initial sync; DB retained stale date until manual correction.

## Changes

- `src/lib/scraper/syncQueue.js` — `enqueue()` only; `.select()` extended to include `source_url`
- `src/__tests__/scraper/syncQueue.test.js` — 4 new B-3 tests; 1 existing "done" test updated to use matching URLs

## Test plan

- [ ] 1051 tests, 0 failures (verified locally)
- [ ] CI green
- [ ] Post-merge: trigger `runScheduleSync` — any appointment whose `sync_queue.source_url` differs from the current AGYD URL should log `🔄 Re-queued modified appointment` and advance to `pending`
